### PR TITLE
Upgrade AU Base 6.1.1-draft, AU Core 2.1.0-draft, IPS 2.0.1 (Issues #43 #45 #46)

### DIFF
--- a/module-config/packages/package-au-base-6.1.1-draft.json
+++ b/module-config/packages/package-au-base-6.1.1-draft.json
@@ -1,6 +1,6 @@
 {
   "name": "hl7.fhir.au.base",
-  "version": "6.0.0",
+  "version": "6.1.1-draft",
   "installMode": "STORE_ONLY",
   "fetchDependencies": true
 }

--- a/module-config/packages/package-aucore-2.1.0-draft.json
+++ b/module-config/packages/package-aucore-2.1.0-draft.json
@@ -1,6 +1,6 @@
 {
   "name": "hl7.fhir.au.core",
-  "version": "2.0.0",
+  "version": "2.1.0-draft",
   "installMode": "STORE_AND_INSTALL",
   "fetchDependencies": false
 }

--- a/module-config/packages/package-international-patient-summary-2.0.1.json
+++ b/module-config/packages/package-international-patient-summary-2.0.1.json
@@ -1,0 +1,7 @@
+{
+  "name": "hl7.fhir.uv.ips",
+  "version": "2.0.1",
+  "installMode": "STORE_ONLY",
+  "fetchDependencies": true,
+  "packageUrl": "https://hl7.org/fhir/uv/ips/2.0.1/package.tgz"
+}

--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -18,7 +18,7 @@ cdrNodes:
           seed.base_validation_resources: true
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
-          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.0.0.json classpath:/config_seeding/package-au-patient-summary-1.0.0-preview.json classpath:/config_seeding/package-aucore-2.0.0.json classpath:/config_seeding/package-international-patient-summary-2.0.0.json"
+          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-au-patient-summary-1.0.0-preview.json classpath:/config_seeding/package-aucore-2.1.0-draft.json classpath:/config_seeding/package-international-patient-summary-2.0.1.json"
           resource_types.supported.whitelist: "MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,Questionnaire,StructureMap,AllergyIntolerance,Condition,Encounter,Immunization,Location,Observation,Organization,Patient,Practitioner,PractitionerRole,Procedure,Medication,MedicationRequest,Coverage,Specimen,RelatedPerson,HealthcareService,QuestionnaireResponse"
           metadata.resource_counts.enabled: false
           validator.local_reference_policy: "NOT_VALIDATED"
@@ -97,7 +97,7 @@ cdrNodes:
           seed.base_validation_resources: true
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
-          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.0.0.json classpath:/config_seeding/package-aucore-2.0.0.json"
+          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-aucore-2.1.0-draft.json"
           resource_types.supported.whitelist: "MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,Questionnaire,StructureMap,AllergyIntolerance,Condition,Encounter,Immunization,Location,Observation,Organization,Patient,Practitioner,PractitionerRole,Procedure,Medication,MedicationRequest,Coverage,Specimen,RelatedPerson,HealthcareService,QuestionnaireResponse"
           metadata.resource_counts.enabled: false
           validator.local_reference_policy: "NOT_VALIDATED"
@@ -153,7 +153,7 @@ cdrNodes:
           seed.base_validation_resources: false
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
-          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.0.0.json classpath:/config_seeding/package-au-erequesting-1.0.0.json classpath:/config_seeding/package-aucore-2.0.0.json classpath:/config_seeding/package-international-patient-summary-2.0.0.json"
+          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-au-erequesting-1.0.0.json classpath:/config_seeding/package-aucore-2.1.0-draft.json classpath:/config_seeding/package-international-patient-summary-2.0.0.json"
           resource_types.supported.whitelist: "Medication,AllergyIntolerance,MedicationRequest,Immunization,HealthcareService, Specimen,MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,CodeSystem,ValueSet,ServiceRequest,Task,Organization,Location,Patient,Practitioner,PractitionerRole,Encounter,Coverage,Condition,DocumentReference,Observation,Procedure,RelatedPerson"
           metadata.resource_counts.enabled: false
           validator.local_reference_policy: "NOT_VALIDATED"

--- a/module-config/values-common.yaml
+++ b/module-config/values-common.yaml
@@ -19,11 +19,13 @@ serviceAccount:
 mappedFiles:
   # logback.xml:
   #   path: /home/smile/smilecdr/classes
-  package-aucore-2.0.0.json:
+  package-aucore-2.1.0-draft.json:
+    path: /home/smile/smilecdr/classes/config_seeding
+  package-international-patient-summary-2.0.1.json:
     path: /home/smile/smilecdr/classes/config_seeding
   package-international-patient-summary-2.0.0.json:
     path: /home/smile/smilecdr/classes/config_seeding
-  package-au-base-6.0.0.json:
+  package-au-base-6.1.1-draft.json:
     path: /home/smile/smilecdr/classes/config_seeding
   package-au-erequesting-1.0.0.json:
     path: /home/smile/smilecdr/classes/config_seeding

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,19 +15,24 @@ module "smile_cdr_dependencies" {
   helm_chart_mapped_files = [
     # Package specifications
     {
+      name     = "package-international-patient-summary-2.0.1.json"
+      location = "classes/config_seeding"
+      data     = file("../module-config/packages/package-international-patient-summary-2.0.1.json")
+    },
+    {
       name     = "package-international-patient-summary-2.0.0.json"
       location = "classes/config_seeding"
       data     = file("../module-config/packages/package-international-patient-summary-2.0.0.json")
     },
     {
-      name     = "package-aucore-2.0.0.json"
+      name     = "package-aucore-2.1.0-draft.json"
       location = "classes/config_seeding"
-      data     = file("../module-config/packages/package-aucore-2.0.0.json")
+      data     = file("../module-config/packages/package-aucore-2.1.0-draft.json")
     },
     {
-      name     = "package-au-base-6.0.0.json"
+      name     = "package-au-base-6.1.1-draft.json"
       location = "classes/config_seeding"
-      data     = file("../module-config/packages/package-au-base-6.0.0.json")
+      data     = file("../module-config/packages/package-au-base-6.1.1-draft.json")
     },
     {
       name     = "package-au-erequesting-1.0.0.json"


### PR DESCRIPTION
## Coordinated IG upgrade for the July 2026 Sparked Testing Event

Upgrades three co-deployed packages. Implemented as a reviewed PR rather than via `ready-for-automation` because the current automation cannot express all of these changes correctly (see "Why not automated" below).

Refs #43 (IPS 2.0.1), #45 (AU Core 2.1.0-draft), #46 (AU Base 6.1.1-draft).

### Changes

| Package | From → To | Nodes | installMode | fetchDeps | packageUrl |
|---|---|---|---|---|---|
| `hl7.fhir.au.base` | 6.0.0 → **6.1.1-draft** | aucore, hl7au, ereq | STORE_ONLY | true | none (registry) |
| `hl7.fhir.au.core` | 2.0.0 → **2.1.0-draft** | aucore, hl7au, ereq | STORE_AND_INSTALL | false | none (registry) |
| `hl7.fhir.uv.ips` | 2.0.0 → **2.0.1** | **aucore only** | STORE_ONLY | true | HL7 publication `package.tgz` |

Per-node `startup_installation_specs` after this change:
- **aucore**: au-base 6.1.1-draft, au-ps 1.0.0-preview, au-core 2.1.0-draft, ips **2.0.1**
- **hl7au**: au-base 6.1.1-draft, au-core 2.1.0-draft
- **ereq**: au-base 6.1.1-draft, au-erequesting 1.0.0, au-core 2.1.0-draft, ips **2.0.0** (unchanged)

Files:
- **New**: `package-au-base-6.1.1-draft.json`, `package-aucore-2.1.0-draft.json`, `package-international-patient-summary-2.0.1.json`
- **Removed**: `package-au-base-6.0.0.json`, `package-aucore-2.0.0.json` (no longer referenced by any node)
- **Updated**: `simplified-multinode.yaml`, `values-common.yaml` (mappedFiles), `terraform/main.tf` (mapped file refs)
- `package-international-patient-summary-2.0.0.json` **retained**, still referenced by ereq

### Package resolution notes

- All three versions resolve from the default registry `packages.fhir.org` (GET; note the registry returns 404 to HEAD requests) and from Simplifier. So AU Base/Core need **no** `packageUrl`, matching the existing `2.0.0` / `au.ps preview` pattern.
- IPS 2.0.1 is pinned to the HL7 publication tarball per #43. As of this PR the Simplifier/registry copy now matches the publication build date (`20260619005948`), so the original "stale Simplifier" reason appears resolved, so the `packageUrl` is retained as an explicit, safe pin and can be dropped later if desired.
- Verified each tarball's `package.json` `name`/`version` matches the config.

### Scope decisions (please confirm)

- **IPS on ereq**: #43 requested aucore only, so ereq stays on IPS 2.0.0. If ereq should also move to 2.0.1, say so and I'll extend it (this also lets us drop the 2.0.0 file entirely).
- **AU PS 1.0.0-preview** remains on aucore. #42 (AU PS 1.0.0) is intentionally not actioned yet. Note the preview was built against AU Core 2.0.0; running it alongside AU Core 2.1.0-draft is untested; flagging for awareness.
- **Terminology**: AU Base/Core 2.1.0-draft code systems & value sets on the remote tx server (`tx.dev.hl7.org.au`) are governed by the separate tx-content process, not this PR. If validation needs the new terminology, a tx-content request is a prerequisite.

### Why not `ready-for-automation`

The IG-release automation would have produced an incorrect result for these Updates:
1. It **appends** the new version to `startup_installation_specs` without removing the old one → both `2.0.0` and `2.1.0-draft` would load simultaneously.
2. It derives the package filename from the display name (`package-au-core-…`) which wouldn't match the existing `package-aucore-2.0.0.json`, so the old file would be orphaned rather than replaced.
3. It cannot emit a `packageUrl`, which #43 requires for IPS.

**Update:** PR #48 has since merged and fixes all three gaps (replace-by-id, orphan cleanup, Custom Package URL). This PR predates that fix and was done by hand; it produces the same result the automation now generates, so it is safe to merge as-is. No rebase is needed (it shares no files with #48).

### Deploy / rollback

- Deploy after merge: Actions → "Reload IG Packages for SmileCDR Nodes" (or on next restart). Start with aucore, then hl7au, then ereq (per the config-map ordering note).
- Rollback: revert this PR and re-apply.
