### PR TITLE
Reload workflow: report accurate install status and fix custom_packages quoting

### DIFF
--- a/.github/workflows/reload-ig-config.yml
+++ b/.github/workflows/reload-ig-config.yml
@@ -114,27 +114,35 @@ jobs:
         env:
           SMILECDR_BASE_URL: ${{ steps.inputs.outputs.base_url }}
           SMILECDR_AUTH_BASIC: ${{ secrets.auth_token || secrets.CSIRO_FHIR_AUTH_64 }}
+          # Passed via env (not inline ${{ }}) so the custom_packages JSON keeps
+          # its double quotes and reaches the script as a single argument.
+          NODES: ${{ steps.inputs.outputs.nodes }}
+          PACKAGE_SOURCE: ${{ steps.inputs.outputs.package_source }}
+          CUSTOM_PACKAGES: ${{ steps.inputs.outputs.custom_packages }}
+          DRY_RUN: ${{ steps.inputs.outputs.dry_run }}
+          FORCE_REINSTALL: ${{ steps.inputs.outputs.force_reinstall }}
         run: |
-          # Build command arguments
-          ARGS="--nodes ${{ steps.inputs.outputs.nodes }}"
-          ARGS="$ARGS --source ${{ steps.inputs.outputs.package_source }}"
+          # Build command arguments as an array so the custom_packages JSON is
+          # preserved as one quoted argument (previously the quotes were stripped
+          # by word-splitting, breaking the 'custom' source).
+          ARGS=(--nodes "$NODES" --source "$PACKAGE_SOURCE")
 
-          if [ "${{ steps.inputs.outputs.dry_run }}" = "true" ]; then
-            ARGS="$ARGS --dry-run"
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
           fi
 
-          if [ "${{ steps.inputs.outputs.force_reinstall }}" = "true" ]; then
-            ARGS="$ARGS --force-reinstall"
+          if [ "$FORCE_REINSTALL" = "true" ]; then
+            ARGS+=(--force-reinstall)
           fi
 
-          if [ "${{ steps.inputs.outputs.package_source }}" = "custom" ]; then
-            ARGS="$ARGS --packages ${{ steps.inputs.outputs.custom_packages }}"
+          if [ "$PACKAGE_SOURCE" = "custom" ]; then
+            ARGS+=(--packages "$CUSTOM_PACKAGES")
           fi
 
           # Run the script and capture output
-          echo "Running: python scripts/sync_packages.py $ARGS"
+          echo "Running: python scripts/sync_packages.py ${ARGS[*]}"
           set +e  # Don't exit on error
-          OUTPUT=$(python scripts/sync_packages.py $ARGS 2>&1)
+          OUTPUT=$(python scripts/sync_packages.py "${ARGS[@]}" 2>&1)
           EXIT_CODE=$?
           set -e
 

--- a/scripts/sync_packages.py
+++ b/scripts/sync_packages.py
@@ -106,6 +106,25 @@ class SmileCDRPackageSync:
             # Continue anyway - package might not be installed
             return False
 
+    def is_package_installed(self, node_name: str, package_name: str, package_version: str) -> bool:
+        """Return True if a specific package@version is registered on a node.
+
+        Used to confirm the real post-install state, since SmileCDR can return a
+        500 while re-inserting an already-present dependency even though the
+        target package itself installed correctly.
+        """
+        url = f"{self.base_url}/{node_name}/package/npm/-/v1/search"
+        try:
+            response = requests.get(url, headers=self.headers, timeout=30)
+            response.raise_for_status()
+            for obj in response.json().get('objects', []):
+                pkg = obj.get('package', {})
+                if pkg.get('name') == package_name and pkg.get('version') == package_version:
+                    return True
+        except requests.exceptions.RequestException:
+            pass
+        return False
+
     def install_package(self, node_name: str, package: Dict) -> bool:
         """Install a package on a node"""
         url = f"{self.base_url}/{node_name}/package/write/install/by-spec"
@@ -141,9 +160,20 @@ class SmileCDRPackageSync:
             print(f"      ✅ Installed successfully")
             return True
         except requests.exceptions.RequestException as e:
+            response_text = getattr(getattr(e, 'response', None), 'text', '') or ''
+            # SmileCDR may return a 500 when fetchDependencies re-inserts a
+            # dependency package that already exists (e.g. duplicate key on
+            # hl7.terminology.r4). The target package itself is still installed,
+            # so confirm the real state before treating this as a failure.
+            if self.is_package_installed(node_name, package_name, package_version):
+                print(f"      ⚠️  Install returned an error, but "
+                      f"{package_name}@{package_version} is registered on {node_name}; treating as success")
+                if response_text:
+                    print(f"      (server message: {response_text[:300]})")
+                return True
             print(f"      ❌ Error installing: {e}")
-            if hasattr(e, 'response') and hasattr(e.response, 'text'):
-                print(f"      Response: {e.response.text}")
+            if response_text:
+                print(f"      Response: {response_text}")
             return False
 
     def sync_node(self, node_name: str, desired_packages: List[Dict], force_reinstall: bool = False, skip_uninstall: bool = False) -> bool:


### PR DESCRIPTION
## Make the reload workflow report the truth, and fix the custom source

Found while deploying #43 / #45 / #46: the live `Re/load IG Packages` run reported **failure**, but the packages had actually installed correctly on all three nodes. Two independent issues.

### 1. False-negative install failures (`scripts/sync_packages.py`)

With `fetchDependencies: true`, SmileCDR returns a **500** when it re-inserts a dependency package that already exists on the node (e.g. `duplicate key value violates unique constraint "idx_packver"` for `hl7.terminology.r4 7.2.0` / `hl7.fhir.uv.xver-r5.r4 0.1.0`). The requested package itself installs fine; only the dependency re-insert errors.

`install_package` now re-queries `/{node}/package/npm/-/v1/search` after a failed install call and treats it as success when the target `package@version` is actually registered. A genuinely absent package still returns failure. New helper: `is_package_installed`.

This keeps `fetchDependencies: true` working (so cold-start dependency resolution is unaffected) while making reloads report accurately. Note: cascade-uninstalling dependencies was considered and rejected, since dependencies are shared across IGs (THO 7.2.0 backs au.base, au.core, and IPS at once).

### 2. `custom_packages` JSON quoting bug (`reload-ig-config.yml`)

The custom package spec was interpolated inline and word-split, stripping the JSON double quotes, so `--packages [{name:...}]` reached the script unquoted and could not be parsed (the `custom` source was effectively broken). Inputs now pass through `env:` vars and the command is built with a bash array, so the JSON arrives intact as one argument.

### Testing

- **Fallback logic** unit-tested both ways: a mocked 500 with the package present returns success; a 500 with the package absent still returns failure.
- **Live**: force-reinstalled `au.base 6.1.1-draft` on aucore through the updated script (with a quoted custom JSON spec); it parsed the spec, reinstalled cleanly, and left au.base registered.
- YAML validated; `sync_packages.py` compiles.

Not merged; no mainline change. Complements the earlier automation fixes in #48.
