### PR TITLE
Upgrade AU Patient Summary 1.0.0-preview to 1.0.0 on aucore (Issue #42)

### DIFF
--- a/module-config/packages/package-au-patient-summary-1.0.0.json
+++ b/module-config/packages/package-au-patient-summary-1.0.0.json
@@ -1,6 +1,6 @@
 {
   "name": "hl7.fhir.au.ps",
-  "version": "1.0.0-preview",
+  "version": "1.0.0",
   "installMode": "STORE_AND_INSTALL",
   "fetchDependencies": false
 }

--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -18,7 +18,7 @@ cdrNodes:
           seed.base_validation_resources: true
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
-          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-au-patient-summary-1.0.0-preview.json classpath:/config_seeding/package-aucore-2.1.0-draft.json classpath:/config_seeding/package-international-patient-summary-2.0.1.json"
+          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-au-patient-summary-1.0.0.json classpath:/config_seeding/package-aucore-2.1.0-draft.json classpath:/config_seeding/package-international-patient-summary-2.0.1.json"
           resource_types.supported.whitelist: "MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,Questionnaire,StructureMap,AllergyIntolerance,Condition,Encounter,Immunization,Location,Observation,Organization,Patient,Practitioner,PractitionerRole,Procedure,Medication,MedicationRequest,Coverage,Specimen,RelatedPerson,HealthcareService,QuestionnaireResponse"
           metadata.resource_counts.enabled: false
           validator.local_reference_policy: "NOT_VALIDATED"

--- a/module-config/values-common.yaml
+++ b/module-config/values-common.yaml
@@ -29,7 +29,7 @@ mappedFiles:
     path: /home/smile/smilecdr/classes/config_seeding
   package-au-erequesting-1.0.0.json:
     path: /home/smile/smilecdr/classes/config_seeding
-  package-au-patient-summary-1.0.0-preview.json:
+  package-au-patient-summary-1.0.0.json:
     path: /home/smile/smilecdr/classes/config_seeding
 
 # Mount users.json from AWS Secrets Manager

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -46,9 +46,9 @@ module "smile_cdr_dependencies" {
       data     = file("../module-config/smart-post-authorize.js")
     },
     {
-      name     = "package-au-patient-summary-1.0.0-preview.json"
+      name     = "package-au-patient-summary-1.0.0.json"
       location = "classes/config_seeding"
-      data     = file("../module-config/packages/package-au-patient-summary-1.0.0-preview.json")
+      data     = file("../module-config/packages/package-au-patient-summary-1.0.0.json")
     },
     # Users configuration moved to AWS Secrets Manager - see extra_secrets below
   ]


### PR DESCRIPTION
## Upgrade AU Patient Summary to 1.0.0 on aucore

AU PS 1.0.0 has been released (`hl7.fhir.au.ps#1.0.0`). This replaces the `1.0.0-preview` package on the **aucore** node.

Refs #42.

### Changes
- `hl7.fhir.au.ps` `1.0.0-preview` to **1.0.0** on aucore (STORE_AND_INSTALL, fetchDependencies false; resolves from packages.fhir.org, no packageUrl needed).
- Superseded `package-au-patient-summary-1.0.0-preview.json` removed, along with its `values-common.yaml` and `terraform/main.tf` references.
- Generated with `scripts/apply_ig_release.py` (the in-place replace path added in #48).

### Notes
- The terminology server watch for au.ps was already moved to 1.0.0 (status trial-use) in a separate change, so no tx change is needed here.
- AU PS 1.0.0 declares a dependency on `hl7.fhir.au.core 2.0.0`, while aucore now runs `au.core 2.1.0-draft` for the July 2026 testing event. Both are present via the registry and `fetchDependencies` is false, so no second au.core version is pulled; flagging the soft-dependency version difference for awareness.

Not deployed by this PR; a `config`-source reload follows the merge.
