### PR TITLE
Add explicit service catalogue layer over GitHub issue requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-general-request.yml
+++ b/.github/ISSUE_TEMPLATE/06-general-request.yml
@@ -1,0 +1,82 @@
+name: General / Bug / Question
+description: Report a bug, ask a question, request an enhancement, or anything not covered by a specific request type (including rollback).
+title: "[General]: "
+labels: ["needs-review", "question"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## General / Bug / Question
+        Use this form when your request does not match one of the specific catalogue offerings
+        (IG Release, Configuration Change, Operational Request, Terminology Content Change, or
+        SMART App Registration).
+
+        **Not sure which to use?** Browse the [Service Catalogue](https://github.com/aehrc/sparked-fhir-server-configuration/blob/main/docs/SERVICE-CATALOGUE.md).
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Request Category
+      description: What kind of request is this?
+      options:
+        - Bug report
+        - Question / help
+        - Enhancement / feature request
+        - Rollback request
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A one-line summary of the request.
+      placeholder: "Short, specific summary of the issue or question"
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: |
+        Full description of the request.
+        For a **bug report**, please include: steps to reproduce, expected vs actual behaviour,
+        and the affected node/environment (e.g. aucore, ereq, hl7au, tx.dev).
+      placeholder: "Describe what you need, or what went wrong and how to reproduce it."
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who or what is affected, and how badly? (optional)
+      placeholder: "e.g. Blocks connectathon testing on aucore for the whole team."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this? (The team confirms and applies a priority label during triage.)
+      options:
+        - Low - can wait
+        - Medium
+        - High
+        - Critical
+    validations:
+      required: false
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact
+      description: Email or handle for follow-up (optional).
+      placeholder: "name@example.org"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# Issue template chooser configuration.
+# Blank issues are disabled so every request enters through a catalogue offering.
+# The "General / Bug / Question" template (06) is the safety net for anything that
+# does not match a specific offering, including bug reports, questions, enhancement
+# ideas, and rollback requests.
+blank_issues_enabled: false
+contact_links:
+  - name: Service Catalogue (browse all request types)
+    url: https://github.com/aehrc/sparked-fhir-server-configuration/blob/main/docs/SERVICE-CATALOGUE.md
+    about: See every request type, what it does, its SLA, and what happens after you submit.
+  - name: Request workflow & lifecycle reference
+    url: https://github.com/aehrc/sparked-fhir-server-configuration/blob/main/docs/WORKFLOWS.md
+    about: How requests are reviewed, automated, deployed, and verified.
+  # Replace the URL below with the team's Zulip stream when available.
+  - name: Chat & announcements (team Zulip)
+    url: https://github.com/aehrc/sparked-fhir-server-configuration/blob/main/README.md#communication-channels
+    about: For quick questions, help choosing a request type, or release announcements.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,6 +1,11 @@
-# GitHub Labels Configuration
-# Use with: gh label create --force $(cat .github/labels.yml)
-# Or manually create these labels in GitHub UI
+# GitHub Labels Configuration - source of truth for the label-sync workflow
+# (.github/workflows/sync-labels.yml). Synced NON-DESTRUCTIVELY: labels absent
+# here are never pruned. scripts/setup-labels.sh must be kept in sync with this file.
+#
+# Do NOT rename these trigger labels - the issue automation matches them as exact
+# strings and renaming would silently break it:
+#   ig-release, tx-content, configuration, operations, smart-client,
+#   ready-for-automation, approved, auto-pr-created, deploy-immediately
 
 # Request Types
 - name: "ig-release"
@@ -19,10 +24,14 @@
   color: "006b75"
   description: "Terminology server content change request"
 
-# Status Labels (simplified flow: needs-review → approved → in-progress → deployed → complete)
+# Status Labels (flow: needs-review → approved → ready-for-automation → in-progress → deployed → complete)
 - name: "needs-review"
   color: "fbca04"
   description: "Awaiting technical review"
+
+- name: "needs-revision"
+  color: "fbef2c"
+  description: "Returned to requestor for changes before review can continue"
 
 - name: "approved"
   color: "0e8a16"
@@ -62,6 +71,14 @@
   description: "Low - Can wait for next scheduled release"
 
 # General Labels
+- name: "bug"
+  color: "d73a4a"
+  description: "Something is not working"
+
+- name: "enhancement"
+  color: "a2eeef"
+  description: "New feature or improvement request"
+
 - name: "automation"
   color: "bfdadc"
   description: "Request to automate an operation"

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,38 @@
+name: Add Issue to Service Catalogue Board
+
+# Adds every newly opened (or reopened) issue to the "Sparked FHIR Server - Service
+# Catalogue" GitHub Project so the team and product owner get an at-a-glance view of
+# every request and its status.
+#
+# SAFETY: this workflow is INERT until it is configured. It only runs when the repo
+# variable CATALOGUE_PROJECT_URL is set AND the ADD_TO_PROJECT_PAT secret is present,
+# so merging it before the board exists (or before a token is provided) is a no-op.
+#
+# To activate:
+#   1. Create the project board (see docs/SERVICE-CATALOGUE.md, "Admin note: project board").
+#   2. Set repo variable CATALOGUE_PROJECT_URL to the project URL.
+#   3. Set repo secret ADD_TO_PROJECT_PAT to a token with Projects read/write
+#      (classic PAT with `project` + `repo`, or a fine-grained token with
+#      Projects: read/write and Issues: read). The default GITHUB_TOKEN cannot
+#      write to org/user Projects (v2), so a PAT is required.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    if: ${{ vars.CATALOGUE_PROJECT_URL != '' }}
+    steps:
+      - name: Add issue to project
+        env:
+          PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        if: ${{ env.PAT != '' }}
+        uses: actions/add-to-project@v1
+        with:
+          project-url: ${{ vars.CATALOGUE_PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,43 @@
+name: Sync Labels
+
+# Keeps the repository's labels in sync with .github/labels.yml (the source of truth
+# for the service catalogue's request-type, status, priority, and automation labels).
+#
+# This sync is NON-DESTRUCTIVE: skip-delete is true, so labels that are not listed in
+# labels.yml (e.g. GitHub defaults or ad-hoc labels) are never pruned. Renaming a label
+# here would break the label-driven automation, so treat labels.yml as append/update only.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/sync-labels.yml"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview changes without applying them"
+        type: boolean
+        default: false
+
+concurrency:
+  group: sync-labels
+  cancel-in-progress: false
+
+permissions:
+  issues: write
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels from .github/labels.yml
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ See **[SMART App Registration Guide](docs/SMART-APP-REGISTRATION.md)**
 
 | Document | Purpose | Audience |
 |----------|---------|----------|
+| **[Service Catalogue](docs/SERVICE-CATALOGUE.md)** | Menu of every request type, its SLA, and what happens after you submit | Everyone |
 | **[Workflow Guide](docs/WORKFLOWS.md)** | Complete guide to all automated workflows | Everyone |
 | **[SMART App Registration](docs/SMART-APP-REGISTRATION.md)** | Register SMART on FHIR / OIDC clients | Developers/Participants |
 | **[Scripts README](scripts/README.md)** | How to use Python scripts locally | Developers/Admins |
@@ -115,11 +116,15 @@ The server currently hosts (see [module-config/packages/](module-config/packages
 ```
 sparked-fhir-server-configuration/
 ├── .github/
-│   ├── ISSUE_TEMPLATE/          # Request templates
+│   ├── ISSUE_TEMPLATE/          # Service catalogue request forms
+│   │   ├── config.yml                     # Chooser config (blank issues disabled)
 │   │   ├── 01-ig-release-request.yml
 │   │   ├── 02-configuration-change.yml
 │   │   ├── 03-operational-request.yml
-│   │   └── 05-smart-app-registration.yml
+│   │   ├── 04-tx-content-change.yml
+│   │   ├── 05-smart-app-registration.yml
+│   │   └── 06-general-request.yml
+│   ├── labels.yml               # Label source of truth (synced by sync-labels.yml)
 │   └── workflows/               # GitHub Actions automation
 │       ├── issue-opened.yml            # Validates requests on creation
 │       ├── issue-labeled.yml           # Creates PRs automatically
@@ -130,8 +135,11 @@ sparked-fhir-server-configuration/
 │       ├── manage-test-data.yml        # Common test data operations (clear+load, expunge)
 │       ├── register-smart-clients.yml  # Register SMART/OIDC clients
 │       ├── validate-config.yml         # Validates config on PR
+│       ├── sync-labels.yml             # Syncs labels.yml (non-destructive)
+│       ├── add-to-project.yml          # Adds new issues to the catalogue board
 │       └── smile-application.yml       # Terraform plan/apply
 ├── docs/
+│   ├── SERVICE-CATALOGUE.md          # Catalogue of request types, SLAs, lifecycle
 │   ├── WORKFLOWS.md                  # Complete workflow guide
 │   ├── SMART-APP-REGISTRATION.md     # SMART/OIDC client registration guide
 │   └── confluence-connectathon-entry.md  # Content for Confluence connectathon pages
@@ -242,25 +250,37 @@ sparked-fhir-server-configuration/
 - **Deployment verification** - User confirms functionality
 - **Issue closure** - Admin closes after verification
 
+## Service Catalogue
+
+Every change to the Sparked FHIR Server is requested as a structured issue. Pick the
+offering that matches your need and click **Raise request**. Blank issues are disabled, so
+anything that does not fit a specific offering (a bug, a question, an idea, or a rollback)
+goes through **General / Bug / Question**.
+
+| Offering | What it's for | Automation | Target SLA | Raise request |
+|----------|---------------|------------|------------|---------------|
+| **IG Release** | Add, update, or roll back a FHIR Implementation Guide | Semi-automated | 1 to 2 weeks | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=01-ig-release-request.yml) |
+| **Configuration Change** | Change Smile CDR modules, endpoints, security, or settings | Manual | 1 to 3 weeks | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=02-configuration-change.yml) |
+| **Operational Request** | Load test data, expunge, refresh, restart, backup/restore | Semi-automated | Hours to days | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=03-operational-request.yml) |
+| **Terminology Content Change** | Add/remove/modify IG packages on tx.dev / tx.hl7 | Semi-automated | 1 to 2 weeks | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=04-tx-content-change.yml) |
+| **SMART App / OIDC Registration** | Register a SMART on FHIR or backend OIDC client | Semi-automated | 1 to 3 business days | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=05-smart-app-registration.yml) |
+| **General / Bug / Question** | Anything not covered above, including rollback | Manual (triage) | Best-effort | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=06-general-request.yml) |
+
+See the full request lifecycle, per-offering detail, and label legend in
+**[docs/SERVICE-CATALOGUE.md](docs/SERVICE-CATALOGUE.md)**.
+
 ## Making Requests
-
-### Types of Requests
-
-| Type | Use When | Example | Timeline |
-|------|----------|---------|----------|
-| **IG Release** | Adding/updating FHIR specifications | "Deploy IPS 3.0.0 to aucore and hl7au" | 1-2 weeks |
-| **Configuration** | Changing server behavior | "Enable FHIR subscriptions on ereq node" | 1-3 weeks |
-| **Operations** | Loading/managing data | "Load 50 test patients for testing" | Hours to days |
 
 ### Request Status Labels
 
 Watch your issue for status updates:
 
 - `needs-review` → Awaiting admin review
+- `needs-revision` → Returned to you for changes before review continues
 - `approved` → Approved, ready to implement
 - `ready-for-automation` → Approved for automated PR generation
 - `in-progress` → PR created, being reviewed
-- `deploy-immediately` → (optional) Deploy automatically once the PR merges
+- `deploy-immediately` → (optional flag) Deploy automatically once the PR merges
 - `deployed` → Deployed, please verify
 - `complete` → Verified and closed
 

--- a/docs/SERVICE-CATALOGUE.md
+++ b/docs/SERVICE-CATALOGUE.md
@@ -1,0 +1,287 @@
+# Sparked FHIR Server - Service Catalogue
+
+Every change to the Sparked FHIR Server is requested as a structured GitHub issue. This
+catalogue is the menu of what you can request, what each request does, how long it takes,
+and what happens after you submit. Pick the offering that matches your need, click **Raise
+request**, and fill in the form.
+
+**Overall SLA posture:** best-effort for non-production environments. Production changes
+must be tested in dev/staging first, and all deployments must be verified by the requestor.
+As a best practice (not a hard SLA), an admin acknowledges new requests within 24 hours.
+
+---
+
+## How to use this catalogue
+
+1. Find the offering below that matches what you need.
+2. Click its **Raise request** link. This opens a pre-filled issue form.
+3. Fill in the form. Non-technical requestors can fill in what they can; the team helps
+   with the technical fields.
+4. Watch the labels on your issue. They track your request through the [lifecycle](#request-lifecycle).
+5. When the request reaches `deployed`, test it and confirm on the issue so it can be
+   marked `complete`.
+
+Blank issues are disabled. If nothing here fits (a bug, a question, an idea, or a
+rollback), use the **General / Bug / Question** offering.
+
+---
+
+## Offerings
+
+| Offering | What it's for | Audience | Automation | Target SLA | Raise request |
+|----------|---------------|----------|------------|------------|---------------|
+| [Implementation Guide Release](#implementation-guide-release) | Add, update, or roll back a FHIR IG on the server nodes | Anyone (team assists) | Semi-automated | 1 to 2 weeks | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=01-ig-release-request.yml) |
+| [Configuration Change](#configuration-change) | Change Smile CDR modules, endpoints, security, or settings | Anyone (team assists) | Manual | 1 to 3 weeks | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=02-configuration-change.yml) |
+| [Operational Request](#operational-request) | Load test data, expunge, refresh, restart, backup/restore | Operators & testers | Semi-automated (test-data load) | Hours to days | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=03-operational-request.yml) |
+| [Terminology Content Change](#terminology-content-change) | Add/remove/modify IG packages on tx.dev / tx.hl7 | Technical requestors | Semi-automated | 1 to 2 weeks | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=04-tx-content-change.yml) |
+| [SMART App / OIDC Client Registration](#smart-app--oidc-client-registration) | Register a SMART on FHIR or backend OIDC client | App/backend developers | Semi-automated | 1 to 3 business days | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=05-smart-app-registration.yml) |
+| [General / Bug / Question](#general--bug--question) | Anything not covered above, including rollback | Everyone | Manual (triage) | Best-effort | [Raise request](https://github.com/aehrc/sparked-fhir-server-configuration/issues/new?template=06-general-request.yml) |
+
+---
+
+## Offering detail
+
+### Implementation Guide Release
+
+Deploy a new or updated FHIR Implementation Guide (new IG, version update, or rollback) to
+the Sparked FHIR Server nodes.
+
+- **Audience:** technical and non-technical requestors. Non-technical users can fill in
+  what they can; the team completes the technical details.
+- **Required inputs:** IG name, IG version, NPM package ID, urgency, request type.
+- **Optional inputs:** IG documentation URL, custom package `.tgz` URL, target nodes
+  (aucore / ereq / hl7au), immediate-deployment preference, test-data/examples needs, and
+  package install options.
+- **Fulfilment:** automated validation runs a dry-run and posts a preview comment. An admin
+  gates the request by adding `ready-for-automation`, which triggers an automated PR that
+  edits the package and Terraform config. A human reviews and merges the PR. If
+  `deploy-immediately` was requested, deployment runs automatically after merge; otherwise
+  the team deploys on a schedule.
+- **Automation level:** semi-automated (validate then auto-PR then human merge then optional
+  auto-deploy).
+- **SLA:** 1 to 2 weeks end-to-end (calendar lead time); roughly 20 minutes of hands-on time
+  once `ready-for-automation` is applied. Add 1 to 2 weeks if an ADR is required.
+- **Example:** "Deploy IPS 2.0.1 to aucore and hl7au, deploy immediately."
+
+### Configuration Change
+
+Change the Smile CDR server configuration: FHIR modules, endpoints, security/access control,
+database configuration, or performance tuning.
+
+- **Audience:** technical and non-technical requestors, focused on describing intent rather
+  than implementation.
+- **Required inputs:** type of change, current state, desired state, business justification,
+  urgency, testing/verification plan, stakeholders/approvers.
+- **Optional inputs:** technical detail (files to modify), impact analysis, dependencies,
+  rollback plan.
+- **Fulfilment:** the request is reviewed and (if significant) may require an ADR. An admin
+  implements the change by hand, tests it, and verifies with the requestor. There is no
+  auto-PR for configuration changes.
+- **Automation level:** manual (an automated welcome comment and priority label are the only
+  automation).
+- **SLA:** 1 to 3 weeks depending on complexity. Add 1 to 2 weeks if an ADR is required.
+- **Example:** "Enable FHIR subscriptions on the ereq node."
+
+### Operational Request
+
+Run operational tasks such as loading test data, expunging/deleting data, refreshing an
+environment, migrating data, restarting a server, or backup/restore.
+
+- **Audience:** operators and testers.
+- **Required inputs:** operation type, urgency, operation details, frequency, business
+  justification, safety confirmation, verification plan, stakeholders/notification.
+- **Optional inputs:** resource types and scope, data source (for loads), timing
+  constraints, rollback/recovery plan, automation request.
+- **Fulfilment:** only **Load test data** is automated: once an admin adds `approved`, the
+  test-data load runs automatically. All other operations (expunge, delete, restart, etc.)
+  are handled by hand after review.
+- **Automation level:** semi-automated for test-data loads; manual otherwise.
+- **SLA:** hours to days depending on data volume; test-data loads take roughly 10 to 30
+  minutes of run time once `approved`.
+- **Example:** "Load 50 test patients into aucore for connectathon testing."
+
+### Terminology Content Change
+
+Add, remove, or modify the IG packages watched on the Sparked terminology servers (tx.dev /
+tx.hl7) via atomio-ig-feeder.
+
+- **Audience:** technical requestors familiar with FHIR package concepts (package IDs,
+  package-list.json, version modes, Atomio feeds).
+- **Required inputs:** action type, package ID, version mode, urgency, business
+  justification.
+- **Optional inputs:** target terminology server(s), package-list.json URL, display name,
+  release statuses to include, pinned versions, Atomio feed name.
+- **Fulfilment:** automated validation runs a dry-run and posts a preview. An admin adds
+  `ready-for-automation`, which triggers an automated PR editing the terminology helm values.
+  A human merges the PR; the atomio-ig-feeder picks up the change on its next sync cycle.
+- **Automation level:** semi-automated (validate then auto-PR then human merge then feeder
+  sync).
+- **SLA:** target 1 to 2 weeks; the live effect depends on the feeder's next sync after merge.
+- **Example:** "Watch hl7.fhir.au.core trial-use versions on tx.dev."
+
+### SMART App / OIDC Client Registration
+
+Register a SMART on FHIR public (PKCE) client or a backend confidential (OIDC) client on the
+server nodes.
+
+- **Audience:** app and backend developers comfortable with OAuth2 (scopes, redirect URIs,
+  FHIR resource IDs).
+- **Required inputs:** client ID, client name, client type, scopes, contact email, urgency,
+  business justification.
+- **Optional inputs:** target nodes, redirect URIs (required in practice for SMART App
+  Launch), Practitioner and Patient launch-context resource IDs.
+- **Fulfilment:** an admin reviews and adds `ready-for-automation`, which registers the
+  client live on each target node. There is no PR. On success the issue receives
+  `auto-registered` and endpoint details are posted; on failure it receives
+  `needs-manual-intervention`.
+- **Automation level:** semi-automated (human gate then live registration).
+- **SLA:** registration itself takes about 5 minutes once approved; overall target 1 to 3
+  business days to approval.
+- **Example:** "Register a public PKCE client `beda-emr` with patient/*.read on aucore."
+
+### General / Bug / Question
+
+Report a bug, ask a question, request an enhancement, or anything not covered by a specific
+offering (including rollback). This is the safety net now that blank issues are disabled.
+
+- **Audience:** everyone.
+- **Required inputs:** request category, summary, details.
+- **Optional inputs:** impact, priority, contact.
+- **Fulfilment:** triaged by an admin, who applies the right labels (for example swapping
+  `question` for `bug` or `enhancement`) and routes the work.
+- **Automation level:** manual (triage only).
+- **SLA:** best-effort; an admin acknowledges within roughly 24 hours (not a hard SLA).
+- **Example:** "Rollback AU Core 2.1.0-draft on aucore, it broke validation."
+
+---
+
+## Request lifecycle
+
+Every issue moves through a label-driven lifecycle. The template auto-applies the request
+type and `needs-review` on open. Automation and admins move it forward from there.
+
+```mermaid
+stateDiagram-v2
+    [*] --> needs_review : issue opened (template auto-labels type + needs-review)
+
+    needs_review --> needs_revision : reviewer requests changes
+    needs_revision --> needs_review : requestor updates issue
+
+    needs_review --> approved : admin approves
+    note right of approved
+      operations "Load test data" path
+      is gated on the 'approved' label
+    end note
+
+    approved --> ready_for_automation : admin arms automation (ig-release / tx-content / smart-client)
+    approved --> in_progress : manual path (configuration, most operations)
+
+    ready_for_automation --> in_progress : auto-PR created (ig/tx) OR client registered (smart)
+    note right of ready_for_automation
+      'deploy-immediately' may be set here
+      as an optional flag (not a status)
+    end note
+
+    in_progress --> deployed : PR merged / change applied / client live
+    deployed --> complete : requestor verifies
+
+    complete --> [*]
+
+    needs_review --> blocked : external dependency
+    approved --> blocked
+    in_progress --> blocked
+    blocked --> needs_review : unblocked (resume triage)
+    blocked --> in_progress : unblocked (resume work)
+```
+
+| State | Meaning | Who acts |
+|-------|---------|----------|
+| `needs-review` | Awaiting triage/technical review (auto-applied on open) | Admin |
+| `needs-revision` | Returned to the requestor for changes before review continues | Requestor |
+| `approved` | Approved to proceed; also the gate for the test-data load path | Admin |
+| `ready-for-automation` | Approved specifically for automation; the gate automation watches | Admin |
+| `in-progress` | PR created, work underway, or client being registered | Automation / Admin |
+| `deployed` | Change applied; awaiting requestor verification | Automation / Admin |
+| `complete` | Verified and closed | Requestor confirms, Admin closes |
+| `blocked` | Waiting on an external dependency (orthogonal to the states above) | Admin |
+
+`deploy-immediately` is a **flag**, not a lifecycle state: it is a requestor preference that
+tells the automation to deploy an IG release as soon as the PR merges.
+
+---
+
+## Label legend
+
+Colours are reused across meanings, so **disambiguate by name, not colour**.
+
+**Request type** (one auto-applied per template): `ig-release`, `configuration`,
+`operations`, `tx-content`, `smart-client`.
+
+**Status / lifecycle:** `needs-review`, `needs-revision`, `approved`, `in-progress`,
+`deployed`, `complete`, `blocked`.
+
+**Priority:** `priority:critical`, `priority:high`, `priority:medium`, `priority:low`.
+
+**Automation gates / states:** `ready-for-automation`, `auto-pr-created`, `auto-registered`,
+`needs-manual-intervention`, `deploy-immediately`.
+
+**General / triage:** `bug`, `enhancement`, `question`, `documentation`, `duplicate`,
+`wontfix`, `automation`.
+
+> **Known colour collisions (disambiguate by name):**
+> `approved` and `ready-for-automation` share green (`0e8a16`); `deployed` and `complete`
+> share green (`28a745`); `deploy-immediately`, `blocked`, `priority:high`, and
+> `needs-manual-intervention` share red (`d93f0b`); `needs-review` and `priority:medium`
+> share yellow (`fbca04`).
+
+The labels are version-controlled in [`.github/labels.yml`](../.github/labels.yml) and kept
+in sync by [`.github/workflows/sync-labels.yml`](../.github/workflows/sync-labels.yml)
+(non-destructive: labels not listed there are never deleted). Do not rename the trigger
+labels listed at the top of `labels.yml`, or the automation will break.
+
+---
+
+## What happens after you submit
+
+1. **Welcome comment.** On open, automation posts a next-steps comment and auto-applies a
+   priority label based on the urgency you selected.
+2. **Validation preview** (IG Release and Terminology Content only). Automation runs a
+   dry-run and posts a validation and preview comment. On success it removes `needs-review`.
+3. **Human gate.** An admin reviews and, when ready, adds `approved` (test-data loads) or
+   `ready-for-automation` (IG / terminology / SMART client).
+4. **Automated action.**
+   - IG Release and Terminology Content: an automated PR is created and labelled
+     `auto-pr-created`; a human reviews and merges it.
+   - SMART Client: the client is registered live on the target nodes (no PR).
+   - Test-data load: the load runs automatically.
+5. **Deploy.** For IG releases, deployment runs automatically if `deploy-immediately` was set;
+   otherwise the team deploys on schedule. The issue is labelled `deployed`.
+6. **Verify.** You test the change and confirm on the issue so it can be marked `complete`.
+
+Configuration Changes and non-test-data Operations are handled manually end-to-end; they do
+not produce an automated PR.
+
+---
+
+## Admin note: project board
+
+Newly opened issues are added to the **Sparked FHIR Server - Service Catalogue** GitHub
+Project by [`.github/workflows/add-to-project.yml`](../.github/workflows/add-to-project.yml).
+The board's single-select **Status** field mirrors the lifecycle above (`Needs review` ->
+`Needs revision` -> `Approved` -> `Ready for automation` -> `In progress` ->
+`Deployed (verifying)` -> `Complete` -> `Blocked`).
+
+Automation writes the labels; humans move the board. Group the board by Status for WIP and
+bottleneck visibility, by Offering for demand mix, or filter to
+`priority:critical`/`priority:high` for the escalation queue.
+
+**Activate the board automation** (one-time, admin):
+
+1. Create the project: `gh project create --owner aehrc --title "Sparked FHIR Server - Service Catalogue"`.
+2. Set the repo variable `CATALOGUE_PROJECT_URL` to the project URL
+   (Settings -> Secrets and variables -> Actions -> Variables).
+3. Set the repo secret `ADD_TO_PROJECT_PAT` to a token with Projects read/write
+   (classic PAT with `project` + `repo`, or a fine-grained token with Projects: read/write
+   and Issues: read). The default `GITHUB_TOKEN` cannot write to Projects (v2).
+
+The workflow is inert until both the variable and the secret are set.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -370,16 +370,22 @@ The workflow will:
 | **IG Release** | Add IPS 3.0.0, Update AU Core | 1-2 weeks |
 | **Configuration** | Enable subscriptions, Add endpoint | 1-3 weeks |
 | **Operations** | Load test data, Refresh environment | Hours to days |
+| **Terminology Content** | Watch a package on tx.dev / tx.hl7 | 1-2 weeks |
+| **SMART App / OIDC** | Register a SMART on FHIR client | 1-3 business days |
+| **General / Bug / Question** | Report a bug, ask a question, request a rollback | Best-effort |
+
+See the [Service Catalogue](SERVICE-CATALOGUE.md) for the full menu, per-offering detail, and SLAs.
 
 ### Request Status Labels
 
 Track your request through these stages:
 
 - `needs-review` → Awaiting admin review
+- `needs-revision` → Returned to you for changes before review continues
 - `approved` → Approved, ready to implement
 - `ready-for-automation` → Approved for automated PR generation
 - `in-progress` → PR created, being reviewed
-- `deploy-immediately` → (optional) Deploy automatically once the PR merges
+- `deploy-immediately` → (optional flag) Deploy automatically once the PR merges
 - `deployed` → Deployed, awaiting your verification
 - `complete` → Verified and closed
 

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -12,8 +12,9 @@ gh label create "configuration" --color "1d76db" --description "Configuration ch
 gh label create "operations" --color "5319e7" --description "Operational request (data load, expunge, etc.)" --force
 gh label create "tx-content" --color "006b75" --description "Terminology server content change request" --force
 
-# Status Labels (flow: needs-review → approved → in-progress → deployed → complete)
+# Status Labels (flow: needs-review → approved → ready-for-automation → in-progress → deployed → complete)
 gh label create "needs-review" --color "fbca04" --description "Awaiting technical review" --force
+gh label create "needs-revision" --color "fbef2c" --description "Returned to requestor for changes before review can continue" --force
 gh label create "approved" --color "0e8a16" --description "Request approved, ready to implement" --force
 gh label create "in-progress" --color "0075ca" --description "Work in progress" --force
 gh label create "deployed" --color "28a745" --description "Changes deployed, awaiting verification" --force
@@ -27,6 +28,8 @@ gh label create "priority:medium" --color "fbca04" --description "Medium - Neede
 gh label create "priority:low" --color "c5def5" --description "Low - Can wait for next scheduled release" --force
 
 # General Labels
+gh label create "bug" --color "d73a4a" --description "Something is not working" --force
+gh label create "enhancement" --color "a2eeef" --description "New feature or improvement request" --force
 gh label create "automation" --color "bfdadc" --description "Request to automate an operation" --force
 gh label create "documentation" --color "0075ca" --description "Documentation improvements or requests" --force
 gh label create "question" --color "cc317c" --description "Question or help request" --force


### PR DESCRIPTION
## Summary

The repo already works like a service catalogue (structured issue templates, a label-driven lifecycle, and GitHub Actions fulfilment), but that framing was implicit and a few request types were undocumented. This PR makes it an explicit, self-service catalogue without changing any label-driven automation.

## What changed

**Catalogue front door**
- `.github/ISSUE_TEMPLATE/config.yml` (new): disables blank issues and adds contact links to the catalogue, the workflow guide, and team chat.
- `06-general-request.yml` (new): the safety net for bugs, questions, enhancements, and rollbacks now that blank issues are off. Applies only `needs-review` + `question`, and its priority options deliberately avoid the body-strings the welcome auto-labeler greps, so it cannot mis-fire automation.

**The catalogue itself**
- `docs/SERVICE-CATALOGUE.md` (new): the canonical menu of all six offerings, each with audience, inputs, fulfilment, automation level, and SLA; a Mermaid lifecycle diagram; a label legend (including the known colour collisions); a "what happens after you submit" explainer; and project-board setup notes.
- `README.md`: new Service Catalogue section with one-click "Raise request" deep links; reconciled status-label list and repository-structure tree.
- `docs/WORKFLOWS.md`: completed the request table with the terminology, SMART, and general offerings that were previously undocumented.

**Labels as code (non-breaking)**
- `bug`, `enhancement`, and a new `needs-revision` are now managed in `labels.yml` and `setup-labels.sh` (`bug`/`enhancement` previously relied on GitHub defaults). No existing trigger label is renamed.
- `sync-labels.yml` (new): keeps labels in sync from `labels.yml` non-destructively (`skip-delete`, so defaults and ad-hoc labels are never pruned).

**Optional project board**
- `add-to-project.yml` (new): auto-adds new issues to a service-catalogue board. Inert until both the `CATALOGUE_PROJECT_URL` variable and the `ADD_TO_PROJECT_PAT` secret are set, so it is safe to merge before the board exists.

## Safety

The existing issue automation matches labels as exact strings. This PR renames and removes nothing in the trigger set (`ig-release`, `tx-content`, `configuration`, `operations`, `smart-client`, `ready-for-automation`, `approved`, `auto-pr-created`, `deploy-immediately`); it only adds labels and documentation. Disabling blank issues does not orphan any path because the new general template and contact links cover bugs, questions, enhancements, and rollbacks.

## Follow-up for an admin (optional, to activate the board)

1. `gh project create --owner aehrc --title "Sparked FHIR Server - Service Catalogue"`
2. Set repo variable `CATALOGUE_PROJECT_URL` to the project URL.
3. Set repo secret `ADD_TO_PROJECT_PAT` to a token with Projects read/write.