### PR TITLE
Fix operations test-data request to capture loader inputs reliably

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-operational-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-operational-request.yml
@@ -87,6 +87,56 @@ body:
     validations:
       required: false
 
+  - type: markdown
+    attributes:
+      value: |
+        ### For "Load test data" requests
+        The four fields below are read directly by the automated test-data loader. They apply
+        only when Operation Type is "Load test data"; leave them blank for other operations.
+
+  - type: input
+    id: test-data-source-url
+    attributes:
+      label: Test Data Source URL
+      description: Git repository or URL to load test data from. Leave blank to use the default AU FHIR test data set.
+      placeholder: "https://github.com/hl7au/au-fhir-test-data"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: target-node
+    attributes:
+      label: Target Node
+      description: Which node should the test data load into? Defaults to aucore if left blank.
+      options:
+        - aucore
+        - hl7au
+    validations:
+      required: false
+
+  - type: dropdown
+    id: upload-mode
+    attributes:
+      label: Upload Mode
+      description: How resources are uploaded. Individual (one at a time), bundle (batch), or transaction. Defaults to individual.
+      options:
+        - individual
+        - bundle
+        - transaction
+    validations:
+      required: false
+
+  - type: dropdown
+    id: upload-method
+    attributes:
+      label: Upload Method
+      description: Upload directly to the FHIR server, or via the FHIRFlare proxy. Defaults to direct.
+      options:
+        - direct
+        - fhirflare
+    validations:
+      required: false
+
   - type: dropdown
     id: frequency
     attributes:

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -899,44 +899,75 @@ jobs:
               issueTitle = context.payload.issue.title;
             }
 
-            // Extract data source
-            let dataSource = context.payload.inputs?.data_source || 'https://github.com/hl7au/au-fhir-test-data';
-            const dataSourceMatch = issueBody.match(/Data Source.*?```\s*([\s\S]*?)\s*```/i);
-            if (dataSourceMatch && dataSourceMatch[1].trim()) {
-              dataSource = dataSourceMatch[1].trim().split('\n')[0];
+            // Helper: read the value under a "### <label>" section of an issue-form body.
+            // Returns '' if the section is missing or GitHub rendered "_No response_".
+            function section(label) {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const m = issueBody.match(new RegExp('###\\s*' + escaped + '\\s*\\n([\\s\\S]*?)(?=\\n###\\s|$)', 'i'));
+              if (!m) return '';
+              let v = m[1].trim();
+              if (/^_no response_$/i.test(v)) return '';
+              // strip a surrounding code fence if GitHub rendered one
+              v = v.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/, '').trim();
+              return v;
             }
 
-            // Extract upload mode from issue body keywords
-            let uploadMode = context.payload.inputs?.upload_mode || 'individual';
-            if (issueBody.includes('bundle upload') || issueBody.includes('as bundle')) {
-              uploadMode = 'bundle';
-            } else if (issueBody.includes('transaction')) {
-              uploadMode = 'transaction';
-            }
-
-            // Extract target node from issue body
-            // Look for known node names; default to aucore
-            let targetNode = 'aucore';
             const bodyLower = issueBody.toLowerCase();
-            if (bodyLower.includes('hl7au') || bodyLower.includes('hl7 au')) {
+
+            // Data source: explicit "Test Data Source URL" field, then the legacy fenced
+            // "Data Source" block, then the default test data set.
+            let dataSource = context.payload.inputs?.data_source || 'https://github.com/hl7au/au-fhir-test-data';
+            const dataSourceField = section('Test Data Source URL');
+            if (dataSourceField) {
+              dataSource = dataSourceField.split('\n')[0].trim();
+            } else {
+              const dataSourceMatch = issueBody.match(/Data Source[\s\S]*?```\s*([\s\S]*?)\s*```/i);
+              if (dataSourceMatch && dataSourceMatch[1].trim()) {
+                dataSource = dataSourceMatch[1].trim().split('\n')[0];
+              }
+            }
+
+            // Upload mode: explicit "Upload Mode" field, then body keywords, then default.
+            let uploadMode = context.payload.inputs?.upload_mode || '';
+            const uploadModeField = section('Upload Mode').toLowerCase();
+            if (uploadModeField.includes('transaction')) uploadMode = 'transaction';
+            else if (uploadModeField.includes('bundle')) uploadMode = 'bundle';
+            else if (uploadModeField.includes('individual')) uploadMode = 'individual';
+            if (!uploadMode) {
+              if (issueBody.includes('bundle upload') || issueBody.includes('as bundle')) uploadMode = 'bundle';
+              else if (issueBody.includes('transaction')) uploadMode = 'transaction';
+              else uploadMode = 'individual';
+            }
+
+            // Target node: explicit "Target Node" field, then a custom FHIR URL, then body
+            // mentions, then default (aucore).
+            let targetNode = '';
+            const targetNodeField = section('Target Node').toLowerCase();
+            if (targetNodeField.includes('hl7au')) targetNode = 'hl7au';
+            else if (targetNodeField.includes('aucore')) targetNode = 'aucore';
+            if (!targetNode && (bodyLower.includes('hl7au') || bodyLower.includes('hl7 au'))) {
               targetNode = 'hl7au';
             }
-            // Check if a custom FHIR URL is specified
+            // Legacy free-text "node: hl7au" mention, only if the explicit field was absent.
+            if (!section('Target Node')) {
+              const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|hl7au)[`"]?/i);
+              if (nodeMatch) targetNode = nodeMatch[1].toLowerCase();
+            }
+            // A custom FHIR URL overrides node selection.
             const customUrlMatch = issueBody.match(/(?:fhir[_ ]?(?:server[_ ]?)?url|target[_ ]?url)[:\s]*[`"]?(https?:\/\/[^\s`"]+)/i);
             if (customUrlMatch) {
               targetNode = 'custom';
               core.setOutput('custom_fhir_url', customUrlMatch[1]);
             }
-            // Also check for explicit node mentions like "node: hl7au"
-            const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|hl7au)[`"]?/i);
-            if (nodeMatch) {
-              targetNode = nodeMatch[1].toLowerCase();
-            }
+            if (!targetNode) targetNode = 'aucore';
 
-            // Extract upload method (direct vs fhirflare)
-            let uploadMethod = 'direct';
-            if (bodyLower.includes('fhirflare') || bodyLower.includes('via fhirflare') || bodyLower.includes('proxy')) {
-              uploadMethod = 'fhirflare';
+            // Upload method: explicit "Upload Method" field, then body keywords, then default.
+            let uploadMethod = '';
+            const uploadMethodField = section('Upload Method').toLowerCase();
+            if (uploadMethodField.includes('fhirflare')) uploadMethod = 'fhirflare';
+            else if (uploadMethodField.includes('direct')) uploadMethod = 'direct';
+            if (!uploadMethod) {
+              uploadMethod = (bodyLower.includes('fhirflare') || bodyLower.includes('via fhirflare') || bodyLower.includes('proxy')) ? 'fhirflare' : 'direct';
             }
 
             core.setOutput('issue_number', issueNumber || '');


### PR DESCRIPTION
## Summary

The `load-test-data` automation scraped the issue's free text for target node / upload mode / upload method and required the data source to be wrapped in a code fence. In practice a correctly-filled Operational Request still fell back to the defaults (`aucore` / `individual` / `direct`), and the `Data Source` regex could not span newlines, so the source was effectively always the default AU test data set.

## Changes

- **Template 03:** add explicit **Target Node**, **Upload Mode**, **Upload Method**, and **Test Data Source URL** fields, scoped with a note to the "Load test data" operation and all optional.
- **`issue-labeled.yml`:** rewrite the extractor to read those form sections first via a robust `### <section>` parser, keeping the old keyword heuristics as a fallback so existing issues and manual `workflow_dispatch` runs still work. A custom FHIR URL still overrides the node; `workflow_dispatch` inputs still take priority.

## Testing

The extractor logic was unit-tested against five cases, all passing:
1. New form fully filled (hl7au / bundle / fhirflare / custom source URL)
2. New form with loader fields left at "No response" (defaults to aucore / individual / direct)
3. Legacy free-text issue with no explicit fields (backward compatibility)
4. `workflow_dispatch` inputs (take priority)
5. Custom FHIR URL (overrides node selection)

## Note

This PR is **stacked on `chore/readme-template-cleanup`** (which also edits template 03). GitHub will retarget it to `main` once that PR merges. Merge that one first.