### PR TITLE
Distinguish HL7-hosted reference environments and gate them for approval

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
@@ -95,18 +95,21 @@ body:
       description: |
         Which SmileCDR nodes should this IG package be deployed to?
 
-        **Node Descriptions:**
-        - **aucore**: AU Core FHIR Server - General Australian FHIR profiles and validation
-        - **hl7au**: HL7 AU Base Server - Base Australian specifications and extensions
-        - **ereq**: eRequesting Server - Electronic requesting workflows and integrations
+        All nodes are on the CSIRO-hosted Sparked dev server (`smile.sparked-fhir.com`). This
+        is not the external HL7 AU reference server at `fhir.hl7.org.au`.
 
-        💡 **Tip**: Most Australian IGs should be requested for both `aucore` and `hl7au`. eRequesting-specific IGs should also include `ereq`.
+        **Node Descriptions:**
+        - **aucore**: AU Core node - general Australian FHIR profiles and validation (`smile.sparked-fhir.com/aucore`)
+        - **hl7au**: HL7 AU Base node - Base Australian specifications and extensions (`smile.sparked-fhir.com/hl7au`)
+        - **ereq**: eRequesting node - electronic requesting workflows and integrations (`smile.sparked-fhir.com/ereq`)
+
+        **Tip**: Most Australian IGs should be requested for both `aucore` and `hl7au`. eRequesting-specific IGs should also include `ereq`.
       options:
-        - label: aucore (AU Core Sparked FHIR Server)
+        - label: aucore (Sparked dev AU Core node)
           required: false
-        - label: ereq (AU Core Sparked eRequesting Server)
+        - label: ereq (Sparked dev eRequesting node)
           required: false
-        - label: hl7au (HL7AU Reference Server)
+        - label: hl7au (Sparked dev HL7 AU Base node)
           required: false
   - type: checkboxes
     id: deployment-options

--- a/.github/ISSUE_TEMPLATE/03-operational-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-operational-request.yml
@@ -93,6 +93,9 @@ body:
         ### For "Load test data" requests
         The four fields below are read directly by the automated test-data loader. They apply
         only when Operation Type is "Load test data"; leave them blank for other operations.
+        Target Node covers the CSIRO Sparked dev nodes only. Loading into any other
+        environment (for example the external `fhir.hl7.org.au` reference server) requires the
+        `needs:hl7-approval` label and Brett Esler's sign-off (see Governance in the README).
 
   - type: input
     id: test-data-source-url

--- a/.github/ISSUE_TEMPLATE/04-tx-content-change.yml
+++ b/.github/ISSUE_TEMPLATE/04-tx-content-change.yml
@@ -41,6 +41,14 @@ body:
         - label: tx.hl7 (HL7 AU Reference Server)
           required: false
 
+  - type: markdown
+    attributes:
+      value: |
+        > **Selecting tx.hl7 requires elevated approval.** tx.hl7 is an HL7-hosted reference
+        > environment. A reviewer will add the `needs:hl7-approval` label and the change needs
+        > Brett Esler's sign-off before it is approved or automated. tx.dev (CSIRO) follows the
+        > normal workflow.
+
   - type: input
     id: package-id
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
+++ b/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
@@ -55,9 +55,9 @@ body:
       label: Target Nodes
       description: |
         Select which FHIR server node(s) to register the client on. Each node has its own client registry and auth endpoints.
-        - **aucore**: AU Core / general purpose Sparked FHIR Dev Server
-        - **hl7au**: HL7 AU Reference Server
-        - **ereq**: eRequesting Sparked FHIR Dev Server
+        - **aucore**: AU Core / general purpose Sparked dev server (`smile.sparked-fhir.com/aucore`)
+        - **hl7au**: HL7 AU Base profiles on the Sparked dev server (`smile.sparked-fhir.com/hl7au`), not the external `fhir.hl7.org.au`
+        - **ereq**: eRequesting Sparked dev server (`smile.sparked-fhir.com/ereq`)
       options:
         - label: "aucore"
           required: false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,6 +33,10 @@
   color: "fbef2c"
   description: "Returned to requestor for changes before review can continue"
 
+- name: "needs:hl7-approval"
+  color: "d4520f"
+  description: "Targets an HL7-hosted reference environment (fhir.hl7.org.au or tx.hl7); requires Brett Esler sign-off before approval"
+
 - name: "approved"
   color: "0e8a16"
   description: "Request approved, ready to implement"

--- a/README.md
+++ b/README.md
@@ -84,15 +84,20 @@ Test data management is powered by the [`sparked-test-data-loader`](https://gith
 
 ### SmileCDR Nodes
 
-| Node | Purpose | Database Module |
-|------|---------|----------------|
-| `aucore` | AU Core FHIR profiles and validation | aucore |
-| `hl7au` | HL7 AU Base specifications and extensions | hl7au |
-| `ereq` | eRequesting workflows and integrations | ereq |
-| - | Cluster management | clustermgr |
-| - | FHIR persistence layer | persistence |
-| - | Audit logs | audit |
-| - | Transactions | transaction |
+All FHIR nodes below are CSIRO-hosted on `smile.sparked-fhir.com` and share the CSIRO
+credentials used by the automation. They are the Sparked **dev** environment. Do not confuse
+the `hl7au` node here with the external HL7 AU reference server at `fhir.hl7.org.au`, which is
+a separate system (see [Governance](#governance)).
+
+| Node | Purpose | FHIR endpoint | Database Module |
+|------|---------|---------------|----------------|
+| `aucore` | AU Core FHIR profiles and validation | `smile.sparked-fhir.com/aucore/fhir/DEFAULT` | aucore |
+| `hl7au` | HL7 AU Base profiles (Sparked dev, not `fhir.hl7.org.au`) | `smile.sparked-fhir.com/hl7au/fhir/DEFAULT` | hl7au |
+| `ereq` | eRequesting workflows and integrations | `smile.sparked-fhir.com/ereq/fhir/DEFAULT` | ereq |
+| - | Cluster management | - | clustermgr |
+| - | FHIR persistence layer | - | persistence |
+| - | Audit logs | - | audit |
+| - | Transactions | - | transaction |
 
 ### Current Implementation Guides
 
@@ -296,6 +301,22 @@ python scripts/update_node_packages.py \
 - **ADR Required** for significant technical decisions (new modules, major config changes)
 - **Decision Makers**: DTR, Brett Esler
 - **ADR Timeline**: Add 1-2 weeks to implementation timeline
+
+#### HL7-hosted reference environments (elevated approval)
+
+Two environments are HL7-hosted reference systems, separate from the CSIRO-hosted Sparked
+dev nodes on `smile.sparked-fhir.com`, and require higher scrutiny:
+
+| Environment | What it is | Managed here? |
+|-------------|------------|---------------|
+| `fhir.hl7.org.au` | The official HL7 AU FHIR reference server | Not an automation target; changes are out of band |
+| `tx.hl7` (`synd.tx.hl7.org.au`) | The HL7 AU terminology reference server | Yes, via the Terminology Content offering (`tx-hl7-helm-values.yaml`) |
+
+Any request that changes one of these environments must be labelled **`needs:hl7-approval`**
+and receive **Brett Esler's** sign-off before it is `approved` or `ready-for-automation`.
+This is a documented process gate: reviewers must not approve or arm automation on such a
+request until that sign-off is recorded on the issue. The CSIRO Sparked dev nodes (`aucore`,
+`ereq`, `hl7au`) follow the normal workflow.
 
 ### SLA Expectations
 

--- a/docs/SERVICE-CATALOGUE.md
+++ b/docs/SERVICE-CATALOGUE.md
@@ -117,6 +117,10 @@ tx.hl7) via atomio-ig-feeder.
 - **Automation level:** semi-automated (validate then auto-PR then human merge then feeder
   sync).
 - **SLA:** target 1 to 2 weeks; the live effect depends on the feeder's next sync after merge.
+- **Elevated approval:** `tx.hl7` is an HL7-hosted reference environment. Changes targeting it
+  require the `needs:hl7-approval` label and Brett Esler's sign-off before approval or
+  automation. `tx.dev` (CSIRO) follows the normal workflow. See
+  [Environment scrutiny](#environment-scrutiny).
 - **Example:** "Watch hl7.fhir.au.core trial-use versions on tx.dev."
 
 ### SMART App / OIDC Client Registration
@@ -220,6 +224,9 @@ Colours are reused across meanings, so **disambiguate by name, not colour**.
 **Status / lifecycle:** `needs-review`, `needs-revision`, `approved`, `in-progress`,
 `deployed`, `complete`, `blocked`.
 
+**Governance gates:** `needs:hl7-approval` (change targets an HL7-hosted reference
+environment; requires Brett Esler sign-off, see [Environment scrutiny](#environment-scrutiny)).
+
 **Priority:** `priority:critical`, `priority:high`, `priority:medium`, `priority:low`.
 
 **Automation gates / states:** `ready-for-automation`, `auto-pr-created`, `auto-registered`,
@@ -238,6 +245,29 @@ The labels are version-controlled in [`.github/labels.yml`](../.github/labels.ym
 in sync by [`.github/workflows/sync-labels.yml`](../.github/workflows/sync-labels.yml)
 (non-destructive: labels not listed there are never deleted). Do not rename the trigger
 labels listed at the top of `labels.yml`, or the automation will break.
+
+---
+
+## Environment scrutiny
+
+Not all environments carry the same risk. The catalogue distinguishes CSIRO-hosted Sparked
+dev environments from HL7-hosted reference environments.
+
+| Environment | Host | Scrutiny |
+|-------------|------|----------|
+| `aucore`, `ereq`, `hl7au` nodes | `smile.sparked-fhir.com` (CSIRO) | Normal workflow |
+| `tx.dev` terminology server | `synd.ontoserver.csiro.au` (CSIRO) | Normal workflow |
+| `tx.hl7` terminology server | `synd.tx.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off |
+| `fhir.hl7.org.au` FHIR reference server | `fhir.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off; not an automation target today |
+
+Note that the `hl7au` **node** is the CSIRO Sparked dev instance at
+`smile.sparked-fhir.com/hl7au`. It is not the external HL7 AU reference server at
+`fhir.hl7.org.au`, which is a separate system.
+
+For any request that changes an HL7-hosted reference environment, a reviewer adds
+`needs:hl7-approval` and must not move the request to `approved` or `ready-for-automation`
+until Brett Esler's sign-off is recorded on the issue. This is a documented process gate; it
+is not enforced by automation.
 
 ---
 

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -15,6 +15,7 @@ gh label create "tx-content" --color "006b75" --description "Terminology server 
 # Status Labels (flow: needs-review → approved → ready-for-automation → in-progress → deployed → complete)
 gh label create "needs-review" --color "fbca04" --description "Awaiting technical review" --force
 gh label create "needs-revision" --color "fbef2c" --description "Returned to requestor for changes before review can continue" --force
+gh label create "needs:hl7-approval" --color "d4520f" --description "Targets an HL7-hosted reference environment (fhir.hl7.org.au or tx.hl7); requires Brett Esler sign-off before approval" --force
 gh label create "approved" --color "0e8a16" --description "Request approved, ready to implement" --force
 gh label create "in-progress" --color "0075ca" --description "Work in progress" --force
 gh label create "deployed" --color "28a745" --description "Changes deployed, awaiting verification" --force


### PR DESCRIPTION
## Summary

Addresses the environment distinction raised in review: the repo's `hl7au` node is the CSIRO Sparked dev node at `smile.sparked-fhir.com/hl7au`, which is easily confused with the external HL7 AU reference server at `fhir.hl7.org.au`. HL7-hosted reference environments should require higher scrutiny.

Verified first: `aucore`, `ereq`, and `hl7au` all map to `smile.sparked-fhir.com` (CSIRO auth) in `load-test-data.yml`, `sync_packages.py`, and `register_smart_client.py`. `fhir.hl7.org.au` is not an automation target here. `tx.hl7` (`synd.tx.hl7.org.au`) is HL7-hosted and *is* changed by the Terminology Content automation.

## Changes

**Disambiguation**
- README node table now shows each node's `smile.sparked-fhir.com/...` endpoint and states these are CSIRO dev nodes, not `fhir.hl7.org.au`.
- Fixed the misleading "HL7 AU Reference Server" wording for the `hl7au` node in the SMART (05) and IG (01) templates. Node tokens the automation parses (`aucore`/`ereq`/`hl7au`) are unchanged.

**Governance gate (label + documented policy, per the chosen approach)**
- New `needs:hl7-approval` label in `labels.yml` and `setup-labels.sh`.
- README Governance gains an "HL7-hosted reference environments" subsection; the service catalogue gains an "Environment scrutiny" section and a label-legend entry.
- Policy: a request changing `fhir.hl7.org.au` or `tx.hl7` must carry `needs:hl7-approval` and Brett Esler's sign-off before it is `approved` or `ready-for-automation`.
- Elevated-approval notes added to the Terminology Content template (selecting `tx.hl7`) and the Operational Request template (non-Sparked load targets).

This is a **documented process gate, not enforced by automation** (no automation guard, no CODEOWNERS), matching the selected approach. No repo-access or branch-ruleset changes are required.

## Stacking

This PR is stacked on `fix/ops-testdata-fields` (#53), which is stacked on `chore/readme-template-cleanup` (#52). Merge order: **#52 → #53 → this**. GitHub will retarget each to `main` as the parent merges.