### PR TITLE
Re-land ops fix + HL7 governance; retire hl7au node from catalogue/automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
@@ -95,13 +95,15 @@ body:
       description: |
         Which SmileCDR nodes should this IG package be deployed to?
 
-        All nodes are on the CSIRO-hosted Sparked dev server (`smile.sparked-fhir.com`). This
-        is not the external HL7 AU reference server at `fhir.hl7.org.au`.
+        The `aucore` and `ereq` nodes make up the **Sparked Dev FHIR Server**. The `hl7au` node
+        is the Sparked-hosted development instance of the **HL7 AU Reference Server**'s AU Core
+        node. All are on `smile.sparked-fhir.com`; none is the production HL7 AU reference
+        server at `fhir.hl7.org.au`.
 
         **Node Descriptions:**
-        - **aucore**: AU Core node - general Australian FHIR profiles and validation (`smile.sparked-fhir.com/aucore`)
-        - **hl7au**: HL7 AU Base node - Base Australian specifications and extensions (`smile.sparked-fhir.com/hl7au`)
-        - **ereq**: eRequesting node - electronic requesting workflows and integrations (`smile.sparked-fhir.com/ereq`)
+        - **aucore**: AU Core node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/aucore`)
+        - **ereq**: eRequesting node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/ereq`)
+        - **hl7au**: dev instance of the HL7 AU Reference Server's AU Core node (`smile.sparked-fhir.com/hl7au`); production is the separate `fhir.hl7.org.au/aucore`
 
         **Tip**: Most Australian IGs should be requested for both `aucore` and `hl7au`. eRequesting-specific IGs should also include `ereq`.
       options:
@@ -109,7 +111,7 @@ body:
           required: false
         - label: ereq (Sparked dev eRequesting node)
           required: false
-        - label: hl7au (Sparked dev HL7 AU Base node)
+        - label: hl7au (Sparked dev HL7 AU Reference Server node)
           required: false
   - type: checkboxes
     id: deployment-options

--- a/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
@@ -95,18 +95,21 @@ body:
       description: |
         Which SmileCDR nodes should this IG package be deployed to?
 
-        **Node Descriptions:**
-        - **aucore**: AU Core FHIR Server - General Australian FHIR profiles and validation
-        - **hl7au**: HL7 AU Base Server - Base Australian specifications and extensions
-        - **ereq**: eRequesting Server - Electronic requesting workflows and integrations
+        All nodes are on the CSIRO-hosted Sparked dev server (`smile.sparked-fhir.com`). This
+        is not the external HL7 AU reference server at `fhir.hl7.org.au`.
 
-        💡 **Tip**: Most Australian IGs should be requested for both `aucore` and `hl7au`. eRequesting-specific IGs should also include `ereq`.
+        **Node Descriptions:**
+        - **aucore**: AU Core node - general Australian FHIR profiles and validation (`smile.sparked-fhir.com/aucore`)
+        - **hl7au**: HL7 AU Base node - Base Australian specifications and extensions (`smile.sparked-fhir.com/hl7au`)
+        - **ereq**: eRequesting node - electronic requesting workflows and integrations (`smile.sparked-fhir.com/ereq`)
+
+        **Tip**: Most Australian IGs should be requested for both `aucore` and `hl7au`. eRequesting-specific IGs should also include `ereq`.
       options:
-        - label: aucore (AU Core Sparked FHIR Server)
+        - label: aucore (Sparked dev AU Core node)
           required: false
-        - label: ereq (AU Core Sparked eRequesting Server)
+        - label: ereq (Sparked dev eRequesting node)
           required: false
-        - label: hl7au (HL7AU Reference Server)
+        - label: hl7au (Sparked dev HL7 AU Base node)
           required: false
   - type: checkboxes
     id: deployment-options

--- a/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
@@ -95,23 +95,19 @@ body:
       description: |
         Which SmileCDR nodes should this IG package be deployed to?
 
-        The `aucore` and `ereq` nodes make up the **Sparked Dev FHIR Server**. The `hl7au` node
-        is the Sparked-hosted development instance of the **HL7 AU Reference Server**'s AU Core
-        node. All are on `smile.sparked-fhir.com`; none is the production HL7 AU reference
-        server at `fhir.hl7.org.au`.
+        The `aucore` and `ereq` nodes make up the **Sparked Dev FHIR Server** on
+        `smile.sparked-fhir.com`. This is not the HL7 AU reference server at `fhir.hl7.org.au`,
+        which is a separate system (see the repository Governance notes).
 
         **Node Descriptions:**
         - **aucore**: AU Core node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/aucore`)
         - **ereq**: eRequesting node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/ereq`)
-        - **hl7au**: dev instance of the HL7 AU Reference Server's AU Core node (`smile.sparked-fhir.com/hl7au`); production is the separate `fhir.hl7.org.au/aucore`
 
-        **Tip**: Most Australian IGs should be requested for both `aucore` and `hl7au`. eRequesting-specific IGs should also include `ereq`.
+        **Tip**: Most Australian IGs should be requested for `aucore`. eRequesting-specific IGs should also include `ereq`.
       options:
         - label: aucore (Sparked dev AU Core node)
           required: false
         - label: ereq (Sparked dev eRequesting node)
-          required: false
-        - label: hl7au (Sparked dev HL7 AU Reference Server node)
           required: false
   - type: checkboxes
     id: deployment-options

--- a/.github/ISSUE_TEMPLATE/03-operational-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-operational-request.yml
@@ -87,6 +87,56 @@ body:
     validations:
       required: false
 
+  - type: markdown
+    attributes:
+      value: |
+        ### For "Load test data" requests
+        The four fields below are read directly by the automated test-data loader. They apply
+        only when Operation Type is "Load test data"; leave them blank for other operations.
+
+  - type: input
+    id: test-data-source-url
+    attributes:
+      label: Test Data Source URL
+      description: Git repository or URL to load test data from. Leave blank to use the default AU FHIR test data set.
+      placeholder: "https://github.com/hl7au/au-fhir-test-data"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: target-node
+    attributes:
+      label: Target Node
+      description: Which node should the test data load into? Defaults to aucore if left blank.
+      options:
+        - aucore
+        - hl7au
+    validations:
+      required: false
+
+  - type: dropdown
+    id: upload-mode
+    attributes:
+      label: Upload Mode
+      description: How resources are uploaded. Individual (one at a time), bundle (batch), or transaction. Defaults to individual.
+      options:
+        - individual
+        - bundle
+        - transaction
+    validations:
+      required: false
+
+  - type: dropdown
+    id: upload-method
+    attributes:
+      label: Upload Method
+      description: Upload directly to the FHIR server, or via the FHIRFlare proxy. Defaults to direct.
+      options:
+        - direct
+        - fhirflare
+    validations:
+      required: false
+
   - type: dropdown
     id: frequency
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-operational-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-operational-request.yml
@@ -93,6 +93,9 @@ body:
         ### For "Load test data" requests
         The four fields below are read directly by the automated test-data loader. They apply
         only when Operation Type is "Load test data"; leave them blank for other operations.
+        Target Node covers the CSIRO Sparked dev nodes only. Loading into any other
+        environment (for example the external `fhir.hl7.org.au` reference server) requires the
+        `needs:hl7-approval` label and Brett Esler's sign-off (see Governance in the README).
 
   - type: input
     id: test-data-source-url

--- a/.github/ISSUE_TEMPLATE/03-operational-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-operational-request.yml
@@ -113,7 +113,7 @@ body:
       description: Which node should the test data load into? Defaults to aucore if left blank.
       options:
         - aucore
-        - hl7au
+        - ereq
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/04-tx-content-change.yml
+++ b/.github/ISSUE_TEMPLATE/04-tx-content-change.yml
@@ -41,6 +41,14 @@ body:
         - label: tx.hl7 (HL7 AU Reference Server)
           required: false
 
+  - type: markdown
+    attributes:
+      value: |
+        > **Selecting tx.hl7 requires elevated approval.** tx.hl7 is an HL7-hosted reference
+        > environment. A reviewer will add the `needs:hl7-approval` label and the change needs
+        > Brett Esler's sign-off before it is approved or automated. tx.dev (CSIRO) follows the
+        > normal workflow.
+
   - type: input
     id: package-id
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
+++ b/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
@@ -55,9 +55,9 @@ body:
       label: Target Nodes
       description: |
         Select which FHIR server node(s) to register the client on. Each node has its own client registry and auth endpoints.
-        - **aucore**: AU Core / general purpose Sparked FHIR Dev Server
-        - **hl7au**: HL7 AU Reference Server
-        - **ereq**: eRequesting Sparked FHIR Dev Server
+        - **aucore**: AU Core / general purpose Sparked dev server (`smile.sparked-fhir.com/aucore`)
+        - **hl7au**: HL7 AU Base profiles on the Sparked dev server (`smile.sparked-fhir.com/hl7au`), not the external `fhir.hl7.org.au`
+        - **ereq**: eRequesting Sparked dev server (`smile.sparked-fhir.com/ereq`)
       options:
         - label: "aucore"
           required: false

--- a/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
+++ b/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
@@ -55,9 +55,10 @@ body:
       label: Target Nodes
       description: |
         Select which FHIR server node(s) to register the client on. Each node has its own client registry and auth endpoints.
-        - **aucore**: AU Core / general purpose Sparked dev server (`smile.sparked-fhir.com/aucore`)
-        - **hl7au**: HL7 AU Base profiles on the Sparked dev server (`smile.sparked-fhir.com/hl7au`), not the external `fhir.hl7.org.au`
-        - **ereq**: eRequesting Sparked dev server (`smile.sparked-fhir.com/ereq`)
+        The `aucore` and `ereq` nodes are the Sparked Dev FHIR Server; `hl7au` is the Sparked dev instance of the HL7 AU Reference Server's AU Core node. None is the production `fhir.hl7.org.au`.
+        - **aucore**: AU Core node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/aucore`)
+        - **hl7au**: dev instance of the HL7 AU Reference Server's AU Core node (`smile.sparked-fhir.com/hl7au`)
+        - **ereq**: eRequesting node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/ereq`)
       options:
         - label: "aucore"
           required: false

--- a/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
+++ b/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
@@ -55,14 +55,11 @@ body:
       label: Target Nodes
       description: |
         Select which FHIR server node(s) to register the client on. Each node has its own client registry and auth endpoints.
-        The `aucore` and `ereq` nodes are the Sparked Dev FHIR Server; `hl7au` is the Sparked dev instance of the HL7 AU Reference Server's AU Core node. None is the production `fhir.hl7.org.au`.
+        The `aucore` and `ereq` nodes are the Sparked Dev FHIR Server (`smile.sparked-fhir.com`), not the HL7 AU reference server at `fhir.hl7.org.au`.
         - **aucore**: AU Core node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/aucore`)
-        - **hl7au**: dev instance of the HL7 AU Reference Server's AU Core node (`smile.sparked-fhir.com/hl7au`)
         - **ereq**: eRequesting node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/ereq`)
       options:
         - label: "aucore"
-          required: false
-        - label: "hl7au"
           required: false
         - label: "ereq"
           required: false

--- a/.github/ISSUE_TEMPLATE/06-general-request.yml
+++ b/.github/ISSUE_TEMPLATE/06-general-request.yml
@@ -45,7 +45,7 @@ body:
       description: |
         Full description of the request.
         For a **bug report**, please include: steps to reproduce, expected vs actual behaviour,
-        and the affected node/environment (e.g. aucore, ereq, hl7au, tx.dev).
+        and the affected node/environment (e.g. aucore, ereq, tx.dev).
       placeholder: "Describe what you need, or what went wrong and how to reproduce it."
     validations:
       required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,6 +33,10 @@
   color: "fbef2c"
   description: "Returned to requestor for changes before review can continue"
 
+- name: "needs:hl7-approval"
+  color: "d4520f"
+  description: "Targets an HL7-hosted reference environment (fhir.hl7.org.au or tx.hl7); requires Brett Esler sign-off before approval"
+
 - name: "approved"
   color: "0e8a16"
   description: "Request approved, ready to implement"

--- a/.github/workflows/clear-test-data.yml
+++ b/.github/workflows/clear-test-data.yml
@@ -18,7 +18,6 @@ on:
         default: "aucore"
         options:
           - aucore
-          - hl7au
           - ereq
           - custom
       custom_fhir_url:
@@ -151,7 +150,6 @@ jobs:
           # Resolve FHIR URL from node name
           case "$TARGET_NODE" in
             aucore) FHIR_URL="https://smile.sparked-fhir.com/aucore/fhir/DEFAULT" ;;
-            hl7au)  FHIR_URL="https://smile.sparked-fhir.com/hl7au/fhir/DEFAULT" ;;
             ereq)   FHIR_URL="https://smile.sparked-fhir.com/ereq/fhir/DEFAULT" ;;
             custom) FHIR_URL="$CUSTOM_FHIR_URL" ;;
             *)      echo "::error::Unknown target node: $TARGET_NODE"; exit 1 ;;

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -899,44 +899,75 @@ jobs:
               issueTitle = context.payload.issue.title;
             }
 
-            // Extract data source
-            let dataSource = context.payload.inputs?.data_source || 'https://github.com/hl7au/au-fhir-test-data';
-            const dataSourceMatch = issueBody.match(/Data Source.*?```\s*([\s\S]*?)\s*```/i);
-            if (dataSourceMatch && dataSourceMatch[1].trim()) {
-              dataSource = dataSourceMatch[1].trim().split('\n')[0];
+            // Helper: read the value under a "### <label>" section of an issue-form body.
+            // Returns '' if the section is missing or GitHub rendered "_No response_".
+            function section(label) {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const m = issueBody.match(new RegExp('###\\s*' + escaped + '\\s*\\n([\\s\\S]*?)(?=\\n###\\s|$)', 'i'));
+              if (!m) return '';
+              let v = m[1].trim();
+              if (/^_no response_$/i.test(v)) return '';
+              // strip a surrounding code fence if GitHub rendered one
+              v = v.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/, '').trim();
+              return v;
             }
 
-            // Extract upload mode from issue body keywords
-            let uploadMode = context.payload.inputs?.upload_mode || 'individual';
-            if (issueBody.includes('bundle upload') || issueBody.includes('as bundle')) {
-              uploadMode = 'bundle';
-            } else if (issueBody.includes('transaction')) {
-              uploadMode = 'transaction';
-            }
-
-            // Extract target node from issue body
-            // Look for known node names; default to aucore
-            let targetNode = 'aucore';
             const bodyLower = issueBody.toLowerCase();
-            if (bodyLower.includes('hl7au') || bodyLower.includes('hl7 au')) {
+
+            // Data source: explicit "Test Data Source URL" field, then the legacy fenced
+            // "Data Source" block, then the default test data set.
+            let dataSource = context.payload.inputs?.data_source || 'https://github.com/hl7au/au-fhir-test-data';
+            const dataSourceField = section('Test Data Source URL');
+            if (dataSourceField) {
+              dataSource = dataSourceField.split('\n')[0].trim();
+            } else {
+              const dataSourceMatch = issueBody.match(/Data Source[\s\S]*?```\s*([\s\S]*?)\s*```/i);
+              if (dataSourceMatch && dataSourceMatch[1].trim()) {
+                dataSource = dataSourceMatch[1].trim().split('\n')[0];
+              }
+            }
+
+            // Upload mode: explicit "Upload Mode" field, then body keywords, then default.
+            let uploadMode = context.payload.inputs?.upload_mode || '';
+            const uploadModeField = section('Upload Mode').toLowerCase();
+            if (uploadModeField.includes('transaction')) uploadMode = 'transaction';
+            else if (uploadModeField.includes('bundle')) uploadMode = 'bundle';
+            else if (uploadModeField.includes('individual')) uploadMode = 'individual';
+            if (!uploadMode) {
+              if (issueBody.includes('bundle upload') || issueBody.includes('as bundle')) uploadMode = 'bundle';
+              else if (issueBody.includes('transaction')) uploadMode = 'transaction';
+              else uploadMode = 'individual';
+            }
+
+            // Target node: explicit "Target Node" field, then a custom FHIR URL, then body
+            // mentions, then default (aucore).
+            let targetNode = '';
+            const targetNodeField = section('Target Node').toLowerCase();
+            if (targetNodeField.includes('hl7au')) targetNode = 'hl7au';
+            else if (targetNodeField.includes('aucore')) targetNode = 'aucore';
+            if (!targetNode && (bodyLower.includes('hl7au') || bodyLower.includes('hl7 au'))) {
               targetNode = 'hl7au';
             }
-            // Check if a custom FHIR URL is specified
+            // Legacy free-text "node: hl7au" mention, only if the explicit field was absent.
+            if (!section('Target Node')) {
+              const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|hl7au)[`"]?/i);
+              if (nodeMatch) targetNode = nodeMatch[1].toLowerCase();
+            }
+            // A custom FHIR URL overrides node selection.
             const customUrlMatch = issueBody.match(/(?:fhir[_ ]?(?:server[_ ]?)?url|target[_ ]?url)[:\s]*[`"]?(https?:\/\/[^\s`"]+)/i);
             if (customUrlMatch) {
               targetNode = 'custom';
               core.setOutput('custom_fhir_url', customUrlMatch[1]);
             }
-            // Also check for explicit node mentions like "node: hl7au"
-            const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|hl7au)[`"]?/i);
-            if (nodeMatch) {
-              targetNode = nodeMatch[1].toLowerCase();
-            }
+            if (!targetNode) targetNode = 'aucore';
 
-            // Extract upload method (direct vs fhirflare)
-            let uploadMethod = 'direct';
-            if (bodyLower.includes('fhirflare') || bodyLower.includes('via fhirflare') || bodyLower.includes('proxy')) {
-              uploadMethod = 'fhirflare';
+            // Upload method: explicit "Upload Method" field, then body keywords, then default.
+            let uploadMethod = '';
+            const uploadMethodField = section('Upload Method').toLowerCase();
+            if (uploadMethodField.includes('fhirflare')) uploadMethod = 'fhirflare';
+            else if (uploadMethodField.includes('direct')) uploadMethod = 'direct';
+            if (!uploadMethod) {
+              uploadMethod = (bodyLower.includes('fhirflare') || bodyLower.includes('via fhirflare') || bodyLower.includes('proxy')) ? 'fhirflare' : 'direct';
             }
 
             core.setOutput('issue_number', issueNumber || '');

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -103,7 +103,6 @@ jobs:
               for (const line of lines) {
                 if (line.includes('[x]') || line.includes('[X]')) {
                   if (line.includes('aucore')) selectedNodes.push('aucore');
-                  if (line.includes('hl7au')) selectedNodes.push('hl7au');
                   if (line.includes('ereq')) selectedNodes.push('ereq');
                 }
               }
@@ -939,18 +938,15 @@ jobs:
               else uploadMode = 'individual';
             }
 
-            // Target node: explicit "Target Node" field, then a custom FHIR URL, then body
-            // mentions, then default (aucore).
+            // Target node: explicit "Target Node" field, then a custom FHIR URL, then a
+            // free-text node mention, then default (aucore).
             let targetNode = '';
             const targetNodeField = section('Target Node').toLowerCase();
-            if (targetNodeField.includes('hl7au')) targetNode = 'hl7au';
+            if (targetNodeField.includes('ereq')) targetNode = 'ereq';
             else if (targetNodeField.includes('aucore')) targetNode = 'aucore';
-            if (!targetNode && (bodyLower.includes('hl7au') || bodyLower.includes('hl7 au'))) {
-              targetNode = 'hl7au';
-            }
-            // Legacy free-text "node: hl7au" mention, only if the explicit field was absent.
+            // Legacy free-text "node: <name>" mention, only if the explicit field was absent.
             if (!section('Target Node')) {
-              const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|hl7au)[`"]?/i);
+              const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|ereq)[`"]?/i);
               if (nodeMatch) targetNode = nodeMatch[1].toLowerCase();
             }
             // A custom FHIR URL overrides node selection.
@@ -1072,7 +1068,6 @@ jobs:
               for (const line of lines) {
                 if (line.includes('[x]') || line.includes('[X]')) {
                   if (line.includes('aucore')) selectedNodes.push('aucore');
-                  if (line.includes('hl7au')) selectedNodes.push('hl7au');
                   if (line.includes('ereq')) selectedNodes.push('ereq');
                 }
               }

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -167,7 +167,6 @@ jobs:
               for (const line of lines) {
                 if (line.includes('[x]') || line.includes('[X]')) {
                   if (line.includes('aucore')) selectedNodes.push('aucore');
-                  if (line.includes('hl7au')) selectedNodes.push('hl7au');
                   if (line.includes('ereq')) selectedNodes.push('ereq');
                 }
               }

--- a/.github/workflows/load-test-data.yml
+++ b/.github/workflows/load-test-data.yml
@@ -18,7 +18,6 @@ on:
         default: "aucore"
         options:
           - aucore
-          - hl7au
           - ereq
           - custom
       custom_fhir_url:
@@ -155,7 +154,6 @@ jobs:
           # Resolve FHIR URL from node name
           case "$TARGET_NODE" in
             aucore) FHIR_URL="https://smile.sparked-fhir.com/aucore/fhir/DEFAULT" ;;
-            hl7au)  FHIR_URL="https://smile.sparked-fhir.com/hl7au/fhir/DEFAULT" ;;
             ereq)   FHIR_URL="https://smile.sparked-fhir.com/ereq/fhir/DEFAULT" ;;
             custom) FHIR_URL="$CUSTOM_FHIR_URL" ;;
             *)      echo "::error::Unknown target node: $TARGET_NODE"; exit 1 ;;

--- a/.github/workflows/manage-test-data.yml
+++ b/.github/workflows/manage-test-data.yml
@@ -19,7 +19,6 @@ on:
         default: "aucore"
         options:
           - aucore
-          - hl7au
           - ereq
       dry_run:
         description: "Dry run (preview without making changes)"

--- a/.github/workflows/reload-ig-config.yml
+++ b/.github/workflows/reload-ig-config.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: "https://smile.sparked-fhir.com"
       nodes:
-        description: "Comma-separated list of node names to update (e.g., 'aucore,hl7au,ereq' or 'all' for all nodes)"
+        description: "Comma-separated list of node names to update (e.g., 'aucore,ereq' or 'all' for all nodes)"
         required: true
         default: "aucore"
       package_source:

--- a/README.md
+++ b/README.md
@@ -85,15 +85,16 @@ Test data management is powered by the [`sparked-test-data-loader`](https://gith
 ### SmileCDR Nodes
 
 All FHIR nodes below are CSIRO-hosted on `smile.sparked-fhir.com` and share the CSIRO
-credentials used by the automation. They are the Sparked **dev** environment. Do not confuse
-the `hl7au` node here with the external HL7 AU reference server at `fhir.hl7.org.au`, which is
-a separate system (see [Governance](#governance)).
+credentials used by the automation. The `aucore` and `ereq` nodes make up the **Sparked Dev
+FHIR Server**; the `hl7au` node is the Sparked-hosted **dev instance of the HL7 AU Reference
+Server**'s AU Core node. None of these is the production HL7 AU reference server at
+`fhir.hl7.org.au` (a separate system, see [Governance](#governance)).
 
 | Node | Purpose | FHIR endpoint | Database Module |
 |------|---------|---------------|----------------|
-| `aucore` | AU Core FHIR profiles and validation | `smile.sparked-fhir.com/aucore/fhir/DEFAULT` | aucore |
-| `hl7au` | HL7 AU Base profiles (Sparked dev, not `fhir.hl7.org.au`) | `smile.sparked-fhir.com/hl7au/fhir/DEFAULT` | hl7au |
-| `ereq` | eRequesting workflows and integrations | `smile.sparked-fhir.com/ereq/fhir/DEFAULT` | ereq |
+| `aucore` | AU Core node of the Sparked Dev FHIR Server | `smile.sparked-fhir.com/aucore/fhir/DEFAULT` | aucore |
+| `ereq` | eRequesting node of the Sparked Dev FHIR Server | `smile.sparked-fhir.com/ereq/fhir/DEFAULT` | ereq |
+| `hl7au` | Dev instance of the HL7 AU Reference Server's AU Core node (production is `fhir.hl7.org.au`) | `smile.sparked-fhir.com/hl7au/fhir/DEFAULT` | hl7au |
 | - | Cluster management | - | clustermgr |
 | - | FHIR persistence layer | - | persistence |
 | - | Audit logs | - | audit |

--- a/README.md
+++ b/README.md
@@ -84,15 +84,20 @@ Test data management is powered by the [`sparked-test-data-loader`](https://gith
 
 ### SmileCDR Nodes
 
-| Node | Purpose | Database Module |
-|------|---------|----------------|
-| `aucore` | AU Core FHIR profiles and validation | aucore |
-| `hl7au` | HL7 AU Base specifications and extensions | hl7au |
-| `ereq` | eRequesting workflows and integrations | ereq |
-| - | Cluster management | clustermgr |
-| - | FHIR persistence layer | persistence |
-| - | Audit logs | audit |
-| - | Transactions | transaction |
+All FHIR nodes below are CSIRO-hosted on `smile.sparked-fhir.com` and share the CSIRO
+credentials used by the automation. They are the Sparked **dev** environment. Do not confuse
+the `hl7au` node here with the external HL7 AU reference server at `fhir.hl7.org.au`, which is
+a separate system (see [Governance](#governance)).
+
+| Node | Purpose | FHIR endpoint | Database Module |
+|------|---------|---------------|----------------|
+| `aucore` | AU Core FHIR profiles and validation | `smile.sparked-fhir.com/aucore/fhir/DEFAULT` | aucore |
+| `hl7au` | HL7 AU Base profiles (Sparked dev, not `fhir.hl7.org.au`) | `smile.sparked-fhir.com/hl7au/fhir/DEFAULT` | hl7au |
+| `ereq` | eRequesting workflows and integrations | `smile.sparked-fhir.com/ereq/fhir/DEFAULT` | ereq |
+| - | Cluster management | - | clustermgr |
+| - | FHIR persistence layer | - | persistence |
+| - | Audit logs | - | audit |
+| - | Transactions | - | transaction |
 
 ### Current Implementation Guides
 
@@ -296,6 +301,22 @@ python scripts/update_node_packages.py \
 - **ADR Required** for significant technical decisions (new modules, major config changes)
 - **Decision Makers**: DTR, Brett Esler
 - **ADR Timeline**: Add 1-2 weeks to implementation timeline
+
+#### HL7-hosted reference environments (elevated approval)
+
+Two environments are HL7-hosted reference systems, separate from the CSIRO-hosted Sparked
+dev nodes on `smile.sparked-fhir.com`, and require higher scrutiny:
+
+| Environment | What it is | Managed here? |
+|-------------|------------|---------------|
+| `fhir.hl7.org.au` | The official HL7 AU FHIR reference server | Not an automation target; changes are out of band |
+| `tx.hl7` (`synd.tx.hl7.org.au`) | The HL7 AU terminology reference server | Yes, via the Terminology Content offering (`tx-hl7-helm-values.yaml`) |
+
+Any request that changes one of these environments must be labelled **`needs:hl7-approval`**
+and receive **Brett Esler's** sign-off before it is `approved` or `ready-for-automation`.
+This is a documented process gate: reviewers must not approve or arm automation on such a
+request until that sign-off is recorded on the issue. The CSIRO Sparked dev nodes (`aucore`,
+`ereq`, `hl7au`) follow the normal workflow.
 
 ### SLA Expectations
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository manages the deployment and configuration of a multi-node Smile C
 ### Key Features
 
 - **Automated IG Deployment** - Request and deploy FHIR IGs through GitHub Issues
-- **Multi-Node Configuration** - Deploy to specific SmileCDR nodes (aucore, hl7au, ereq)
+- **Multi-Node Configuration** - Deploy to specific SmileCDR nodes (aucore, ereq)
 - **Automatic Validation** - Instant feedback on configuration changes
 - **Flexible Deployment** - Deploy immediately, schedule for later, or wait for restart
 - **Complete Audit Trail** - All changes tracked in git with issue references
@@ -84,17 +84,15 @@ Test data management is powered by the [`sparked-test-data-loader`](https://gith
 
 ### SmileCDR Nodes
 
-All FHIR nodes below are CSIRO-hosted on `smile.sparked-fhir.com` and share the CSIRO
-credentials used by the automation. The `aucore` and `ereq` nodes make up the **Sparked Dev
-FHIR Server**; the `hl7au` node is the Sparked-hosted **dev instance of the HL7 AU Reference
-Server**'s AU Core node. None of these is the production HL7 AU reference server at
-`fhir.hl7.org.au` (a separate system, see [Governance](#governance)).
+The FHIR nodes below make up the **Sparked Dev FHIR Server**, CSIRO-hosted on
+`smile.sparked-fhir.com` and sharing the CSIRO credentials used by the automation. This is
+not the HL7 AU reference server at `fhir.hl7.org.au`, which is a separate system (see
+[Governance](#governance)).
 
 | Node | Purpose | FHIR endpoint | Database Module |
 |------|---------|---------------|----------------|
 | `aucore` | AU Core node of the Sparked Dev FHIR Server | `smile.sparked-fhir.com/aucore/fhir/DEFAULT` | aucore |
 | `ereq` | eRequesting node of the Sparked Dev FHIR Server | `smile.sparked-fhir.com/ereq/fhir/DEFAULT` | ereq |
-| `hl7au` | Dev instance of the HL7 AU Reference Server's AU Core node (production is `fhir.hl7.org.au`) | `smile.sparked-fhir.com/hl7au/fhir/DEFAULT` | hl7au |
 | - | Cluster management | - | clustermgr |
 | - | FHIR persistence layer | - | persistence |
 | - | Audit logs | - | audit |
@@ -205,7 +203,7 @@ python scripts/sync_packages.py \
 # Test config update (dry-run)
 python scripts/update_node_packages.py \
   --action add \
-  --nodes aucore,hl7au \
+  --nodes aucore,ereq \
   --package package-example.json \
   --dry-run
 
@@ -263,7 +261,7 @@ Actions → "Re/load IG Packages" → Run workflow
 
 # Via script locally
 python scripts/sync_packages.py \
-  --nodes aucore,hl7au \
+  --nodes aucore,ereq \
   --source config \
   --dry-run  # Remove for actual deployment
 ```
@@ -273,7 +271,7 @@ python scripts/sync_packages.py \
 # Add package to nodes
 python scripts/update_node_packages.py \
   --action add \
-  --nodes aucore,hl7au \
+  --nodes aucore,ereq \
   --package package-international-patient-summary-2.0.1.json
 
 # Remove package from nodes
@@ -317,7 +315,7 @@ Any request that changes one of these environments must be labelled **`needs:hl7
 and receive **Brett Esler's** sign-off before it is `approved` or `ready-for-automation`.
 This is a documented process gate: reviewers must not approve or arm automation on such a
 request until that sign-off is recorded on the issue. The CSIRO Sparked dev nodes (`aucore`,
-`ereq`, `hl7au`) follow the normal workflow.
+`ereq`) follow the normal workflow.
 
 ### SLA Expectations
 

--- a/docs/SERVICE-CATALOGUE.md
+++ b/docs/SERVICE-CATALOGUE.md
@@ -117,6 +117,10 @@ tx.hl7) via atomio-ig-feeder.
 - **Automation level:** semi-automated (validate then auto-PR then human merge then feeder
   sync).
 - **SLA:** target 1 to 2 weeks; the live effect depends on the feeder's next sync after merge.
+- **Elevated approval:** `tx.hl7` is an HL7-hosted reference environment. Changes targeting it
+  require the `needs:hl7-approval` label and Brett Esler's sign-off before approval or
+  automation. `tx.dev` (CSIRO) follows the normal workflow. See
+  [Environment scrutiny](#environment-scrutiny).
 - **Example:** "Watch hl7.fhir.au.core trial-use versions on tx.dev."
 
 ### SMART App / OIDC Client Registration
@@ -220,6 +224,9 @@ Colours are reused across meanings, so **disambiguate by name, not colour**.
 **Status / lifecycle:** `needs-review`, `needs-revision`, `approved`, `in-progress`,
 `deployed`, `complete`, `blocked`.
 
+**Governance gates:** `needs:hl7-approval` (change targets an HL7-hosted reference
+environment; requires Brett Esler sign-off, see [Environment scrutiny](#environment-scrutiny)).
+
 **Priority:** `priority:critical`, `priority:high`, `priority:medium`, `priority:low`.
 
 **Automation gates / states:** `ready-for-automation`, `auto-pr-created`, `auto-registered`,
@@ -238,6 +245,29 @@ The labels are version-controlled in [`.github/labels.yml`](../.github/labels.ym
 in sync by [`.github/workflows/sync-labels.yml`](../.github/workflows/sync-labels.yml)
 (non-destructive: labels not listed there are never deleted). Do not rename the trigger
 labels listed at the top of `labels.yml`, or the automation will break.
+
+---
+
+## Environment scrutiny
+
+Not all environments carry the same risk. The catalogue distinguishes CSIRO-hosted Sparked
+dev environments from HL7-hosted reference environments.
+
+| Environment | Host | Scrutiny |
+|-------------|------|----------|
+| `aucore`, `ereq`, `hl7au` nodes | `smile.sparked-fhir.com` (CSIRO) | Normal workflow |
+| `tx.dev` terminology server | `synd.ontoserver.csiro.au` (CSIRO) | Normal workflow |
+| `tx.hl7` terminology server | `synd.tx.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off |
+| `fhir.hl7.org.au` FHIR reference server | `fhir.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off; not an automation target today |
+
+Note that the `hl7au` **node** is the CSIRO Sparked dev instance at
+`smile.sparked-fhir.com/hl7au`. It is not the external HL7 AU reference server at
+`fhir.hl7.org.au`, which is a separate system.
+
+For any request that changes an HL7-hosted reference environment, a reviewer adds
+`needs:hl7-approval` and must not move the request to `approved` or `ready-for-automation`
+until Brett Esler's sign-off is recorded on the issue. This is a documented process gate; it
+is not enforced by automation.
 
 ---
 

--- a/docs/SERVICE-CATALOGUE.md
+++ b/docs/SERVICE-CATALOGUE.md
@@ -260,8 +260,9 @@ dev environments from HL7-hosted reference environments.
 | `tx.hl7` terminology server | `synd.tx.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off |
 | `fhir.hl7.org.au` FHIR reference server | `fhir.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off; not an automation target today |
 
-Note that the `hl7au` **node** is the CSIRO Sparked dev instance at
-`smile.sparked-fhir.com/hl7au`. It is not the external HL7 AU reference server at
+The `aucore` and `ereq` nodes make up the Sparked Dev FHIR Server. The `hl7au` **node** is
+the Sparked-hosted dev instance of the HL7 AU Reference Server's AU Core node
+(`smile.sparked-fhir.com/hl7au`). It is not the production HL7 AU reference server at
 `fhir.hl7.org.au`, which is a separate system.
 
 For any request that changes an HL7-hosted reference environment, a reviewer adds

--- a/docs/SERVICE-CATALOGUE.md
+++ b/docs/SERVICE-CATALOGUE.md
@@ -50,7 +50,7 @@ the Sparked FHIR Server nodes.
   what they can; the team completes the technical details.
 - **Required inputs:** IG name, IG version, NPM package ID, urgency, request type.
 - **Optional inputs:** IG documentation URL, custom package `.tgz` URL, target nodes
-  (aucore / ereq / hl7au), immediate-deployment preference, test-data/examples needs, and
+  (aucore / ereq), immediate-deployment preference, test-data/examples needs, and
   package install options.
 - **Fulfilment:** automated validation runs a dry-run and posts a preview comment. An admin
   gates the request by adding `ready-for-automation`, which triggers an automated PR that
@@ -61,7 +61,7 @@ the Sparked FHIR Server nodes.
   auto-deploy).
 - **SLA:** 1 to 2 weeks end-to-end (calendar lead time); roughly 20 minutes of hands-on time
   once `ready-for-automation` is applied. Add 1 to 2 weeks if an ADR is required.
-- **Example:** "Deploy IPS 2.0.1 to aucore and hl7au, deploy immediately."
+- **Example:** "Deploy IPS 2.0.1 to aucore, deploy immediately."
 
 ### Configuration Change
 
@@ -255,15 +255,14 @@ dev environments from HL7-hosted reference environments.
 
 | Environment | Host | Scrutiny |
 |-------------|------|----------|
-| `aucore`, `ereq`, `hl7au` nodes | `smile.sparked-fhir.com` (CSIRO) | Normal workflow |
+| `aucore`, `ereq` nodes | `smile.sparked-fhir.com` (CSIRO) | Normal workflow |
 | `tx.dev` terminology server | `synd.ontoserver.csiro.au` (CSIRO) | Normal workflow |
 | `tx.hl7` terminology server | `synd.tx.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off |
 | `fhir.hl7.org.au` FHIR reference server | `fhir.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off; not an automation target today |
 
-The `aucore` and `ereq` nodes make up the Sparked Dev FHIR Server. The `hl7au` **node** is
-the Sparked-hosted dev instance of the HL7 AU Reference Server's AU Core node
-(`smile.sparked-fhir.com/hl7au`). It is not the production HL7 AU reference server at
-`fhir.hl7.org.au`, which is a separate system.
+The `aucore` and `ereq` nodes make up the Sparked Dev FHIR Server on `smile.sparked-fhir.com`.
+It is not the production HL7 AU reference server at `fhir.hl7.org.au`, which is a separate
+system.
 
 For any request that changes an HL7-hosted reference environment, a reviewer adds
 `needs:hl7-approval` and must not move the request to `approved` or `ready-for-automation`

--- a/docs/SMART-APP-REGISTRATION.md
+++ b/docs/SMART-APP-REGISTRATION.md
@@ -7,7 +7,6 @@ Complete guide to registering SMART on FHIR / OIDC clients on the Sparked FHIR S
 | Node | FHIR Base | Well-Known | Authorize | Token |
 |------|-----------|------------|-----------|-------|
 | aucore | `https://smile.sparked-fhir.com/aucore/fhir/DEFAULT` | `https://smile.sparked-fhir.com/aucore/smartauth/.well-known/openid-configuration` | `https://smile.sparked-fhir.com/aucore/smartauth/oauth/authorize` | `https://smile.sparked-fhir.com/aucore/smartauth/oauth/token` |
-| hl7au | `https://smile.sparked-fhir.com/hl7au/fhir/DEFAULT` | `https://smile.sparked-fhir.com/hl7au/smartauth/.well-known/openid-configuration` | `https://smile.sparked-fhir.com/hl7au/smartauth/oauth/authorize` | `https://smile.sparked-fhir.com/hl7au/smartauth/oauth/token` |
 | ereq | `https://smile.sparked-fhir.com/ereq/fhir/DEFAULT` | `https://smile.sparked-fhir.com/ereq/smartauth/.well-known/openid-configuration` | `https://smile.sparked-fhir.com/ereq/smartauth/oauth/authorize` | `https://smile.sparked-fhir.com/ereq/smartauth/oauth/token` |
 
 | Endpoint | URL |

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -60,7 +60,7 @@ The system automatically:
 - Name: International Patient Summary
 - Version: 2.0.0
 - Package ID: hl7.fhir.uv.ips
-- Target Nodes: aucore, hl7au
+- Target Nodes: aucore
 
 ### 📦 Dry-Run Preview
 ✅ Dry-run completed successfully!
@@ -97,7 +97,7 @@ A Pull Request has been automatically generated: PR #45
 
 ### What was generated:
 - ✅ Package file: package-ips-2.0.0.json
-- ✅ Updated: simplified-multinode.yaml for aucore, hl7au
+- ✅ Updated: simplified-multinode.yaml for aucore
 - ✅ Updated: terraform/main.tf
 
 ### Next Steps:
@@ -237,7 +237,7 @@ Please verify the data has been loaded as expected.
 1. Go to **Actions** → **Clear Test Data** → **Run workflow**
 2. Select:
    - **Delete mode**: `targeted` (match test data files) or `wipe-all` (everything)
-   - **Target node**: aucore, hl7au, ereq
+   - **Target node**: aucore, ereq
    - **Expunge**: Enable for physical removal (not just soft-delete)
 3. Click **Run workflow**
 
@@ -344,7 +344,7 @@ If you need to deploy packages outside of the automated workflow:
 2. Click **"Run workflow"**
 3. Configure:
    - **Base URL**: `https://smile.sparked-fhir.com` (default)
-   - **Nodes**: `aucore,hl7au` or `all`
+   - **Nodes**: `aucore,ereq` or `all`
    - **Package Source**:
      - `config` - Read from simplified-multinode.yaml (recommended)
      - `packages-dir` - Load all JSON files from packages/
@@ -419,7 +419,7 @@ Track your request through these stages:
 
    **Notes:**
    - Package ID auto-generated as hl7.fhir.uv.ips
-   - Will update aucore and hl7au nodes
+   - Will update aucore and ereq nodes
    - Standard configuration, no special requirements
    ```
 

--- a/docs/connectathon-participant-handout.md
+++ b/docs/connectathon-participant-handout.md
@@ -22,7 +22,7 @@ No — it supports both read and write, but writes require authentication:
 | Authorize | `https://smile.sparked-fhir.com/aucore/smartauth/oauth/authorize` |
 | Token | `https://smile.sparked-fhir.com/aucore/smartauth/oauth/token` |
 
-> Other nodes follow the same pattern with `/hl7au/...` and `/ereq/...` in place of `/aucore/...`.
+> Other nodes follow the same pattern with `/ereq/...` in place of `/aucore/...`.
 > Note the `/oauth/` segment in the authorize/token paths.
 
 ## Getting a client (registration is required for writes)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -201,7 +201,7 @@ python sync_packages.py --nodes all --source config --dry-run
 python sync_packages.py --nodes aucore --source config
 
 # Update multiple specific nodes
-python sync_packages.py --nodes aucore,hl7au --source config
+python sync_packages.py --nodes aucore,ereq --source config
 
 # Force reinstall all packages
 python sync_packages.py --nodes all --source config --force-reinstall

--- a/scripts/apply_ig_release.py
+++ b/scripts/apply_ig_release.py
@@ -28,7 +28,7 @@ Usage:
         --package-id hl7.fhir.au.core \
         --version 2.1.0-draft \
         --ig-name "AU Core" \
-        --nodes aucore,hl7au,ereq \
+        --nodes aucore,ereq \
         --install-mode STORE_AND_INSTALL \
         --fetch-dependencies false \
         --package-url ""            # optional; omit/empty to resolve from registry

--- a/scripts/register_smart_client.py
+++ b/scripts/register_smart_client.py
@@ -72,14 +72,13 @@ DEFAULT_BASE_URL = "https://smile.sparked-fhir.com"
 # Each node has its own smart_auth and local_security modules (from useDefaultModules).
 # Clients and users must be registered per-node on that node's smart_auth module.
 MODULE_ID = "smart_auth"
-SUPPORTED_NODES = ["aucore", "hl7au", "ereq"]
+SUPPORTED_NODES = ["aucore", "ereq"]
 DEFAULT_NODE = "aucore"
 
 # Node-specific configuration for SMART auth context paths and admin API paths.
 # Each node's smart_auth module listens on its own context path.
 NODE_CONFIG = {
     "aucore": {"smartauth_path": "aucore/smartauth", "admin_path": "aucore/admin-json"},
-    "hl7au":  {"smartauth_path": "hl7au/smartauth",  "admin_path": "hl7au/admin-json"},
     "ereq":   {"smartauth_path": "ereq/smartauth",   "admin_path": "ereq/admin-json"},
 }
 

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -15,6 +15,7 @@ gh label create "tx-content" --color "006b75" --description "Terminology server 
 # Status Labels (flow: needs-review → approved → ready-for-automation → in-progress → deployed → complete)
 gh label create "needs-review" --color "fbca04" --description "Awaiting technical review" --force
 gh label create "needs-revision" --color "fbef2c" --description "Returned to requestor for changes before review can continue" --force
+gh label create "needs:hl7-approval" --color "d4520f" --description "Targets an HL7-hosted reference environment (fhir.hl7.org.au or tx.hl7); requires Brett Esler sign-off before approval" --force
 gh label create "approved" --color "0e8a16" --description "Request approved, ready to implement" --force
 gh label create "in-progress" --color "0075ca" --description "Work in progress" --force
 gh label create "deployed" --color "28a745" --description "Changes deployed, awaiting verification" --force

--- a/scripts/sync_packages.py
+++ b/scripts/sync_packages.py
@@ -6,7 +6,7 @@ This script synchronizes FHIR IG packages across SmileCDR nodes.
 
 Usage:
     # From GitHub Actions workflow
-    python sync_packages.py --base-url https://smile.sparked-fhir.com --nodes aucore,hl7au --source config --dry-run
+    python sync_packages.py --base-url https://smile.sparked-fhir.com --nodes aucore,ereq --source config --dry-run
 
     # Or sync all nodes from config
     python sync_packages.py --base-url https://smile.sparked-fhir.com --nodes all --source config

--- a/scripts/update_node_packages.py
+++ b/scripts/update_node_packages.py
@@ -10,19 +10,19 @@ Usage:
     # Add package to nodes
     python update_node_packages.py \
         --action add \
-        --nodes aucore,hl7au \
+        --nodes aucore,ereq \
         --package package-international-patient-summary-2.0.0.json
 
     # Remove package from nodes
     python update_node_packages.py \
         --action remove \
-        --nodes aucore,hl7au \
+        --nodes aucore,ereq \
         --package package-international-patient-summary-2.0.0.json
 
     # Preview changes without applying
     python update_node_packages.py \
         --action add \
-        --nodes aucore,hl7au \
+        --nodes aucore,ereq \
         --package package-international-patient-summary-2.0.0.json \
         --dry-run
 """


### PR DESCRIPTION
## Why this PR exists

When PRs #52 to #54 were merged, only **#52 actually reached `main`** (a stacked-PR squash-merge trap: #53 merged into the #52 branch and #54 into the #53 branch, not into `main`). This PR re-lands the stranded work directly onto `main` (no stacking), and adds the hl7au-node retirement.

## Contents

1. **Re-land #53** - operations test-data request captures loader inputs reliably (explicit Target Node / Upload Mode / Upload Method / Test Data Source URL + robust section parser). Parser unit-tested.
2. **Re-land #54** - HL7-hosted reference environment governance: `needs:hl7-approval` label + documented approval policy for `fhir.hl7.org.au` and `tx.hl7` (Brett Esler sign-off).
3. **Retire the hl7au node from catalogue and automation options** - the `smile.sparked-fhir.com/hl7au` node is being taken offline and its name clashed with the HL7 AU reference server. Removed from: issue templates (01/03/05/06), issue automation parsing (issue-opened/issue-labeled), the load/clear/manage-test-data node choices and FHIR-URL mappings (including the `smile.sparked-fhir.com/hl7au/fhir/DEFAULT` endpoint), `register_smart_client.py` supported nodes, and all docs (README, service catalogue, WORKFLOWS, SMART registration table, connectathon handout). Script examples using `aucore,hl7au` now use `aucore,ereq`.

## Scope / safety

- The **live node's deployment config** (`simplified-multinode.yaml`, `terraform/main.tf`, packages) is deliberately **left intact** - the actual decommission is a separate infra change. The historical `docs/bugs.md` log is left as-is.
- Automation-parsed strings for the remaining nodes (`aucore`, `ereq`) and all label/option strings are unchanged.
- Verified: all templates and workflows parse as YAML, all scripts compile, the test-data parser passes 5 cases (filled form, defaults, legacy free-text, dispatch inputs, custom URL), no `hl7au` remains in any catalogue/automation surface, no em/en dashes introduced.

## Merge note

Single PR based on `main`; a plain squash-merge is safe. After merge, the old branches (`chore/readme-template-cleanup`, `fix/ops-testdata-fields`, `chore/hl7-env-governance`) can be deleted.