### PR TITLE
Guard SMART post-authorize script against null user session

### DIFF
--- a/module-config/smart-post-authorize.js
+++ b/module-config/smart-post-authorize.js
@@ -18,6 +18,14 @@
  * Docs: https://smilecdr.com/docs/smart/user_profile.html
  */
 function onTokenGenerating(theUserSession, theAuthorizationRequestDetails) {
+    // Client Credentials (backend service) flows have no user session: there is
+    // no user, launch context, or fhirUser to inject. Skip all user-oriented
+    // logic, otherwise the theUserSession accessors below throw a null TypeError
+    // and token issuance fails with HTTP 500.
+    if (!theUserSession) {
+        return;
+    }
+
     // getAudience() can return null for standalone launch — use fixed base as fallback
     var audience = theAuthorizationRequestDetails.getAudience()
         || "https://smile.sparked-fhir.com/aucore/fhir/DEFAULT";


### PR DESCRIPTION
## Problem

Backend service (client credentials) token requests to the `smart_auth` module fail with HTTP 500:

```
TokenEndpoint - Handling error: InternalErrorException, Error on line 78
Error: TypeError: Cannot read property "getOrCreateDefaultLaunchContext" from null
Source: theUserSession.getOrCreateDefaultLaunchContext("practitioner")
```

`onTokenGenerating` was written for interactive flows (EHR launch / standalone SMART App Launch) and unconditionally calls `theUserSession` accessors. In the `CLIENT_CREDENTIALS` grant there is no user session, so `theUserSession` is null and token issuance throws.

This was hit while registering a backend service client (`consultmed-ereq-backend`) on the `ereq` node for the 2026-07-08 Sparked Testing Event. It is latent on every node running this script (including `aucore`, which has pre-registered `connectathon-backend-*` clients).

## Fix

Return early from `onTokenGenerating` when `theUserSession` is null. A backend service token has no user, launch context, or fhirUser to inject, so all user-oriented logic is skipped and the token issues normally. Interactive flows are unaffected.

## Verification

After deploying the updated script to the `ereq` node's `smart_auth` module and restarting it, `grant_type=client_credentials` returns HTTP 200 with a valid access token (`scope: system/*.*`).

## Follow-up

The updated script still needs to be deployed to the `aucore` node's `smart_auth` module to clear the same latent 500 there.