### PR TITLE
Raise ingress body size limit to 16m for large transaction Bundles

### DIFF
--- a/module-config/values-common.yaml
+++ b/module-config/values-common.yaml
@@ -1,6 +1,15 @@
 specs:
   hostname: smile.sparked-fhir.com
 
+# Raise the ingress-nginx request body size limit above the 1 MiB nginx default so
+# that larger FHIR transaction Bundles (for example AU eRequesting) are not rejected
+# at the edge with HTTP 413 before reaching Smile CDR. The default ingress fronts
+# smile.sparked-fhir.com via the ingress-nginx controller.
+ingresses:
+  default:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+
 volumeConfig:
   cdr:
     amq:


### PR DESCRIPTION
## Problem

FHIR transaction Bundle POSTs larger than 1 MiB are rejected at the edge with `HTTP 413 Request Entity Too Large`, returned by nginx before the request reaches Smile CDR. This surfaced during the 2026-07-08 Sparked Testing Event when a participant's AU eRequesting export Bundle failed to upload.

Diagnosis against the live `ereq` endpoint confirmed the limit is the stock ingress-nginx `client_max_body_size` default of exactly 1 MiB (1,048,576 bytes):

| Request body | Result |
|--------------|--------|
| up to 1,048,572 B | passes nginx, reaches Smile CDR |
| 1,048,996 B and above | nginx `413` |

Smile CDR itself accepts far larger payloads; the cap is purely at the ingress.

## Change

Set `nginx.ingress.kubernetes.io/proxy-body-size: "16m"` on the chart's `default` ingress in `values-common.yaml`. The `default` ingress is the `nginx-ingress` entry bound to `smile.sparked-fhir.com`, and its annotations map was previously empty (inheriting the nginx default).

`16m` comfortably covers realistic eRequesting Bundle sizes while keeping a sane upper bound. The value is easy to tune later if needed.

## Scope and safety

- No change to Smile CDR request validation, terminology validation, or persistence.
- Only the edge body-size limit changes; nothing else about the ingress is modified.

## Verification after deploy

Confirm the annotation landed on the live ingress and that a >1 MiB Bundle is accepted:

```
kubectl get ingress -A -o yaml | grep -A2 proxy-body-size
```

Then POST a Bundle between 1 MiB and 16 MiB and confirm it is no longer rejected with 413.