### PR TITLE
Enable CI plan-on-PR for the Smile CDR terraform stack (Phase 1)

### DIFF
--- a/.github/workflows/_ci-plan-validation.yml
+++ b/.github/workflows/_ci-plan-validation.yml
@@ -1,0 +1,39 @@
+# TEMPORARY, remove before merging this PR.
+#
+# The real deployment workflow (smile-application.yml) is disabled_manually and
+# must not be re-enabled until Phase 2 is approved. This throwaway workflow runs
+# ONLY the plan job, with the exact inputs smile-application.yml will use, so we
+# can validate plan-on-PR (OIDC, backend injection, var injection, terraform
+# version, fmt/tflint) and get a posted plan comment without re-enabling the
+# real workflow. It has no apply job and cannot trigger an apply.
+#
+# Delete this file once the plan run is green.
+name: 'CI plan validation (temporary)'
+
+on:
+  pull_request:
+    paths:
+      - 'module-config/**'
+      - 'terraform/**'
+      - '.github/workflows/_ci-plan-validation.yml'
+  workflow_dispatch:
+
+jobs:
+  terraform-plan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@chore/terraform-version-input
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    with:
+      working_dir: "terraform"
+      stack_name: smile-app-prod
+      aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      aws_region: ap-southeast-2
+      terraform_version: "1.15.6"
+      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
+      additional_args: >-
+        -var="s3_bucket_name=${{ vars.S3_BUCKET }}"
+        -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}"
+        -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"

--- a/.github/workflows/_ci-plan-validation.yml
+++ b/.github/workflows/_ci-plan-validation.yml
@@ -1,16 +1,10 @@
 # TEMPORARY, remove before merging this PR.
 #
-# The real deployment workflow (smile-application.yml) is disabled_manually and
-# must not be re-enabled until Phase 2 is approved. This throwaway workflow calls
-# the SAME reusable plan template @main, with the exact inputs
-# smile-application.yml passes, so we validate the real plan-on-PR path (OIDC,
-# backend injection, var injection, terraform_version, fmt/tflint) and get a
-# posted plan comment without re-enabling the real workflow. It calls only the
-# plan template, never the apply template, so it cannot trigger an apply.
-#
-# This supersedes the earlier inline version: now that
-# aehrc/sparked-infrastructure#27 is merged, @main carries the terraform_version
-# input and the reusable call resolves (a branch ref would not, on pull_request).
+# smile-application.yml is disabled_manually and must not be re-enabled until
+# Phase 2 is approved, so it cannot run on this PR. This throwaway workflow is a
+# plan-only mirror of its terraform-plan job (identical steps), enabled so it
+# runs on the PR to validate plan-on-PR end to end and post a plan comment. It
+# has no apply job and cannot trigger an apply.
 #
 # Delete this file once the plan run is green.
 name: 'CI plan validation (temporary)'
@@ -23,16 +17,98 @@ on:
       - '.github/workflows/_ci-plan-validation.yml'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   terraform-plan:
+    name: 'Terraform Plan (validation)'
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@main
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
-    with:
-      working_dir: "terraform"
-      stack_name: smile-app-prod-validation
-      aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
-      aws_region: ap-southeast-2
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+          terraform_version: "1.15.6"
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: terraform init -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" -input=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: v0.63.1
+
+      - name: TFLint
+        run: tflint --format compact --minimum-failure-severity=error
+
+      - name: Terraform Plan
+        id: tf-plan
+        run: |
+          export exitcode=0
+          terraform plan \
+            -var="s3_bucket_name=${{ vars.S3_BUCKET }}" \
+            -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}" \
+            -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}" \
+            -detailed-exitcode -no-color -out main.tfplan || export exitcode=$?
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+          echo "exitcode=$exitcode"
+          if [ "$exitcode" -eq 1 ]; then
+            echo "Terraform Plan Failed!"
+            exit 1
+          fi
+          exit 0
+
+      - name: Create String Output
+        id: tf-plan-string
+        run: |
+          TERRAFORM_PLAN=$(terraform show -no-color main.tfplan)
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "summary<<${delimiter}"
+            echo "## Terraform Plan Output (smile-app-prod, validation) - exitcode ${{ steps.tf-plan.outputs.exitcode }}"
+            echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```terraform'
+            echo "$TERRAFORM_PLAN"
+            echo '```'
+            echo "</details>"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push Terraform Output to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `${process.env.SUMMARY}`;
+            github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+            })

--- a/.github/workflows/_ci-plan-validation.yml
+++ b/.github/workflows/_ci-plan-validation.yml
@@ -37,8 +37,5 @@ jobs:
       aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
       aws_region: ap-southeast-2
       terraform_version: "1.15.6"
-      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
-      additional_args: >-
-        -var="s3_bucket_name=${{ vars.S3_BUCKET }}"
-        -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}"
-        -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"
+      init_args: '-backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"'
+      additional_args: '-var="s3_bucket_name=${{ vars.S3_BUCKET }}" -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}" -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"'

--- a/.github/workflows/_ci-plan-validation.yml
+++ b/.github/workflows/_ci-plan-validation.yml
@@ -36,6 +36,3 @@ jobs:
       stack_name: smile-app-prod-validation
       aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
       aws_region: ap-southeast-2
-      terraform_version: "1.15.6"
-      init_args: '-backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"'
-      additional_args: '-var="s3_bucket_name=${{ vars.S3_BUCKET }}" -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}" -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"'

--- a/.github/workflows/_ci-plan-validation.yml
+++ b/.github/workflows/_ci-plan-validation.yml
@@ -1,21 +1,16 @@
 # TEMPORARY, remove before merging this PR.
 #
 # The real deployment workflow (smile-application.yml) is disabled_manually and
-# must not be re-enabled until Phase 2 is approved. This throwaway workflow runs
-# ONLY a plan, inlining the same steps as the reusable plan template with the
-# exact inputs smile-application.yml will pass, so we can validate plan-on-PR
-# (OIDC, backend injection, var injection, Terraform version vs the module,
-# fmt/tflint) and get a posted plan comment without re-enabling the real
-# workflow. It has no apply step and cannot trigger an apply.
+# must not be re-enabled until Phase 2 is approved. This throwaway workflow calls
+# the SAME reusable plan template @main, with the exact inputs
+# smile-application.yml passes, so we validate the real plan-on-PR path (OIDC,
+# backend injection, var injection, terraform_version, fmt/tflint) and get a
+# posted plan comment without re-enabling the real workflow. It calls only the
+# plan template, never the apply template, so it cannot trigger an apply.
 #
-# The steps are inlined (rather than calling the reusable template) because a
-# private cross-repo reusable workflow cannot be referenced at a branch ref on
-# pull_request; the template itself is validated separately (its inputs match
-# the caller, and aehrc/sparked-infrastructure#27 adds terraform_version).
-#
-# Runs on ubuntu-latest: the EKS endpoint is public and the OIDC role has full
-# access, so a GitHub-hosted runner exercises the whole plan path. The
-# self-hosted arc-runner-set path is a Phase 2 (apply) concern.
+# This supersedes the earlier inline version: now that
+# aehrc/sparked-infrastructure#27 is merged, @main carries the terraform_version
+# input and the reusable call resolves (a branch ref would not, on pull_request).
 #
 # Delete this file once the plan run is green.
 name: 'CI plan validation (temporary)'
@@ -28,98 +23,22 @@ on:
       - '.github/workflows/_ci-plan-validation.yml'
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
-
 jobs:
   terraform-plan:
-    name: 'Terraform Plan (validation)'
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: terraform
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
-          aws-region: ap-southeast-2
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
-          terraform_version: "1.15.6"
-
-      - name: Terraform Format
-        run: terraform fmt -check -recursive
-
-      - name: Terraform Init
-        run: terraform init -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" -input=false
-
-      - name: Terraform Validate
-        run: terraform validate
-
-      - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
-        with:
-          tflint_version: v0.63.1
-
-      - name: TFLint
-        run: tflint --format compact --minimum-failure-severity=error
-
-      - name: Terraform Plan
-        id: tf-plan
-        run: |
-          export exitcode=0
-          terraform plan \
-            -var="s3_bucket_name=${{ vars.S3_BUCKET }}" \
-            -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}" \
-            -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}" \
-            -detailed-exitcode -no-color -out main.tfplan || export exitcode=$?
-          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
-          echo "exitcode=$exitcode"
-          if [ "$exitcode" -eq 1 ]; then
-            echo "Terraform Plan Failed!"
-            exit 1
-          fi
-          exit 0
-
-      - name: Create String Output
-        id: tf-plan-string
-        run: |
-          TERRAFORM_PLAN=$(terraform show -no-color main.tfplan)
-          delimiter="$(openssl rand -hex 8)"
-          {
-            echo "summary<<${delimiter}"
-            echo "## Terraform Plan Output (smile-app-prod, validation) - exitcode ${{ steps.tf-plan.outputs.exitcode }}"
-            echo "<details><summary>Click to expand</summary>"
-            echo ""
-            echo '```terraform'
-            echo "$TERRAFORM_PLAN"
-            echo '```'
-            echo "</details>"
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Push Terraform Output to PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const body = `${process.env.SUMMARY}`;
-            github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body
-            })
+    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@main
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    with:
+      working_dir: "terraform"
+      stack_name: smile-app-prod-validation
+      aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      aws_region: ap-southeast-2
+      terraform_version: "1.15.6"
+      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
+      additional_args: >-
+        -var="s3_bucket_name=${{ vars.S3_BUCKET }}"
+        -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}"
+        -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"

--- a/.github/workflows/_ci-plan-validation.yml
+++ b/.github/workflows/_ci-plan-validation.yml
@@ -2,10 +2,20 @@
 #
 # The real deployment workflow (smile-application.yml) is disabled_manually and
 # must not be re-enabled until Phase 2 is approved. This throwaway workflow runs
-# ONLY the plan job, with the exact inputs smile-application.yml will use, so we
-# can validate plan-on-PR (OIDC, backend injection, var injection, terraform
-# version, fmt/tflint) and get a posted plan comment without re-enabling the
-# real workflow. It has no apply job and cannot trigger an apply.
+# ONLY a plan, inlining the same steps as the reusable plan template with the
+# exact inputs smile-application.yml will pass, so we can validate plan-on-PR
+# (OIDC, backend injection, var injection, Terraform version vs the module,
+# fmt/tflint) and get a posted plan comment without re-enabling the real
+# workflow. It has no apply step and cannot trigger an apply.
+#
+# The steps are inlined (rather than calling the reusable template) because a
+# private cross-repo reusable workflow cannot be referenced at a branch ref on
+# pull_request; the template itself is validated separately (its inputs match
+# the caller, and aehrc/sparked-infrastructure#27 adds terraform_version).
+#
+# Runs on ubuntu-latest: the EKS endpoint is public and the OIDC role has full
+# access, so a GitHub-hosted runner exercises the whole plan path. The
+# self-hosted arc-runner-set path is a Phase 2 (apply) concern.
 #
 # Delete this file once the plan run is green.
 name: 'CI plan validation (temporary)'
@@ -18,22 +28,98 @@ on:
       - '.github/workflows/_ci-plan-validation.yml'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   terraform-plan:
+    name: 'Terraform Plan (validation)'
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@chore/terraform-version-input
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
-    with:
-      working_dir: "terraform"
-      stack_name: smile-app-prod
-      aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
-      aws_region: ap-southeast-2
-      terraform_version: "1.15.6"
-      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
-      additional_args: >-
-        -var="s3_bucket_name=${{ vars.S3_BUCKET }}"
-        -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}"
-        -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+          terraform_version: "1.15.6"
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: terraform init -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" -input=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: v0.63.1
+
+      - name: TFLint
+        run: tflint --format compact --minimum-failure-severity=error
+
+      - name: Terraform Plan
+        id: tf-plan
+        run: |
+          export exitcode=0
+          terraform plan \
+            -var="s3_bucket_name=${{ vars.S3_BUCKET }}" \
+            -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}" \
+            -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}" \
+            -detailed-exitcode -no-color -out main.tfplan || export exitcode=$?
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+          echo "exitcode=$exitcode"
+          if [ "$exitcode" -eq 1 ]; then
+            echo "Terraform Plan Failed!"
+            exit 1
+          fi
+          exit 0
+
+      - name: Create String Output
+        id: tf-plan-string
+        run: |
+          TERRAFORM_PLAN=$(terraform show -no-color main.tfplan)
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "summary<<${delimiter}"
+            echo "## Terraform Plan Output (smile-app-prod, validation) - exitcode ${{ steps.tf-plan.outputs.exitcode }}"
+            echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```terraform'
+            echo "$TERRAFORM_PLAN"
+            echo '```'
+            echo "</details>"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push Terraform Output to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `${process.env.SUMMARY}`;
+            github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+            })

--- a/.github/workflows/smile-application.yml
+++ b/.github/workflows/smile-application.yml
@@ -1,5 +1,18 @@
 name: 'Smile Configuration Deployment'
 
+# Plan on PRs, apply on push to main when the plan reports changes.
+#
+# The steps are inlined rather than calling the reusable templates in
+# aehrc/sparked-infrastructure: that repo is private and this repo is public,
+# and GitHub does not allow a public repo to consume a private repo's reusable
+# workflows ("workflow was not found"). The step sequence mirrors
+# template-terraform-plan.yml / template-terraform-apply.yml; keep them roughly
+# in sync when those templates change.
+#
+# backend.hcl and terraform.tfvars are gitignored, so the state bucket and the
+# three no-default variables are injected from repo variables (none are secrets:
+# a bucket name, a Secrets Manager ARN, an IAM role name). AWS auth is OIDC.
+
 on:
   pull_request:
     paths:
@@ -13,48 +26,162 @@ on:
       - 'terraform/**'
   workflow_dispatch: # Manual trigger
 
-# NOTE: the terraform_version input below relies on aehrc/sparked-infrastructure#27
-# (adds terraform_version to the reusable templates). That PR must merge to
-# sparked-infrastructure main before this workflow is enabled in Phase 2; the
-# module (v9.0.2) requires Terraform >= 1.14.3, above the templates' 1.13.4 default.
+permissions:
+  id-token: write      # request the OIDC JWT
+  contents: read       # actions/checkout
+  pull-requests: write # comment the plan on PRs
+
 jobs:
   terraform-plan:
-    # Only run on PRs from the same repo, not forks
+    name: 'Terraform Plan'
+    # Only run on PRs from this repo, not forks (protects OIDC + any self-hosted runner).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@main
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
-    with:
-      working_dir: "terraform"
-      stack_name: smile-app-prod
-      aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
-      aws_region: ap-southeast-2
-      # Module v9.0.2 requires Terraform >= 1.14.3; matches the committed lock file and local applies.
-      terraform_version: "1.15.6"
-      # backend.hcl is gitignored; inject the state bucket (region + key live in the backend block).
-      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
-      # terraform.tfvars is gitignored; supply the three vars without defaults. None are secrets.
-      additional_args: >-
-        -var="s3_bucket_name=${{ vars.S3_BUCKET }}"
-        -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}"
-        -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"
+    # Defaults to GitHub-hosted; set repo var CI_RUNNER to use a self-hosted runner.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    outputs:
+      tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+          # Module v9.0.2 requires Terraform >= 1.14.3; matches the committed lock file and local applies.
+          terraform_version: "1.15.6"
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+
+      # No -upgrade: respect the committed .terraform.lock.hcl. backend.hcl is
+      # gitignored, so inject the state bucket (region + key live in the backend block).
+      - name: Terraform Init
+        run: terraform init -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" -input=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: v0.63.1
+
+      # Error severity only; the stack carries pre-existing warning-level findings.
+      - name: TFLint
+        run: tflint --format compact --minimum-failure-severity=error
+
+      # terraform.tfvars is gitignored, so pass the three no-default vars.
+      - name: Terraform Plan
+        id: tf-plan
+        run: |
+          export exitcode=0
+          terraform plan \
+            -var="s3_bucket_name=${{ vars.S3_BUCKET }}" \
+            -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}" \
+            -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}" \
+            -detailed-exitcode -no-color -out main.tfplan || export exitcode=$?
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+          echo "exitcode=$exitcode"
+          if [ "$exitcode" -eq 1 ]; then
+            echo "Terraform Plan Failed!"
+            exit 1
+          fi
+          exit 0
+
+      - name: Publish Terraform Plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-smile-app-prod
+          path: |
+            terraform/main.tfplan
+            terraform/builds/
+
+      - name: Create String Output
+        id: tf-plan-string
+        run: |
+          TERRAFORM_PLAN=$(terraform show -no-color main.tfplan)
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "summary<<${delimiter}"
+            echo "## Terraform Plan Output (smile-app-prod)"
+            echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```terraform'
+            echo "$TERRAFORM_PLAN"
+            echo '```'
+            echo "</details>"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish Terraform Plan to Task Summary
+        env:
+          SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
+        run: echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push Terraform Output to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `${process.env.SUMMARY}`;
+            github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+            })
 
   terraform-apply:
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-apply.yml@main
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: write
+    name: 'Terraform Apply'
     needs: [terraform-plan]
-    # Only apply on main branch pushes when there are changes (exitcode == 2)
+    # Only apply on main branch pushes when the plan reported changes (exitcode == 2).
     if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.terraform-plan.outputs.tfplanExitCode == '2'
-    with:
-      working_dir: "terraform"
-      stack_name: smile-app-prod
-      aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
-      aws_region: ap-southeast-2
-      # Must match the plan job's version so apply consumes the artifact with a compatible CLI.
-      terraform_version: "1.15.6"
-      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Gate: the infra-apply environment (required reviewers) must exist before enabling apply.
+    environment: infra-apply
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+          # Must match the plan job so the saved plan is applied by a compatible CLI.
+          terraform_version: "1.15.6"
+
+      - name: Terraform Init
+        run: terraform init -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" -input=false
+
+      - name: Download Terraform Plan
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan-smile-app-prod
+          path: terraform
+
+      # Applies exactly the reviewed plan; if state moved since the plan was
+      # created, terraform aborts rather than applying a stale diff.
+      - name: Terraform Apply
+        run: terraform apply -auto-approve main.tfplan

--- a/.github/workflows/smile-application.yml
+++ b/.github/workflows/smile-application.yml
@@ -13,16 +13,15 @@ on:
       - 'terraform/**'
   workflow_dispatch: # Manual trigger
 
-# NOTE (temporary): the reusable templates are pinned to the
-# chore/terraform-version-input branch of aehrc/sparked-infrastructure, which
-# adds the terraform_version input this stack needs (module v9.0.2 requires
-# Terraform >= 1.14.3, the templates default to 1.13.4). Switch both refs back
-# to @main once aehrc/sparked-infrastructure#27 merges, before this PR lands.
+# NOTE: the terraform_version input below relies on aehrc/sparked-infrastructure#27
+# (adds terraform_version to the reusable templates). That PR must merge to
+# sparked-infrastructure main before this workflow is enabled in Phase 2; the
+# module (v9.0.2) requires Terraform >= 1.14.3, above the templates' 1.13.4 default.
 jobs:
   terraform-plan:
     # Only run on PRs from the same repo, not forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@chore/terraform-version-input
+    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@main
     permissions:
       id-token: write
       contents: read
@@ -43,7 +42,7 @@ jobs:
         -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"
 
   terraform-apply:
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-apply.yml@chore/terraform-version-input
+    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-apply.yml@main
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/smile-application.yml
+++ b/.github/workflows/smile-application.yml
@@ -13,22 +13,37 @@ on:
       - 'terraform/**'
   workflow_dispatch: # Manual trigger
 
+# NOTE (temporary): the reusable templates are pinned to the
+# chore/terraform-version-input branch of aehrc/sparked-infrastructure, which
+# adds the terraform_version input this stack needs (module v9.0.2 requires
+# Terraform >= 1.14.3, the templates default to 1.13.4). Switch both refs back
+# to @main once aehrc/sparked-infrastructure#27 merges, before this PR lands.
 jobs:
   terraform-plan:
     # Only run on PRs from the same repo, not forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@main
+    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-plan.yml@chore/terraform-version-input
     permissions:
       id-token: write
       contents: read
       pull-requests: write
     with:
       working_dir: "terraform"
+      stack_name: smile-app-prod
       aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
       aws_region: ap-southeast-2
+      # Module v9.0.2 requires Terraform >= 1.14.3; matches the committed lock file and local applies.
+      terraform_version: "1.15.6"
+      # backend.hcl is gitignored; inject the state bucket (region + key live in the backend block).
+      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"
+      # terraform.tfvars is gitignored; supply the three vars without defaults. None are secrets.
+      additional_args: >-
+        -var="s3_bucket_name=${{ vars.S3_BUCKET }}"
+        -var="cdr_regcred_secret_arn=${{ vars.CDR_REGCRED_SECRET_ARN }}"
+        -var="smilecdr_iam_role_name=${{ vars.SMILECDR_IAM_ROLE_NAME }}"
 
   terraform-apply:
-    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-apply.yml@main
+    uses: aehrc/sparked-infrastructure/.github/workflows/template-terraform-apply.yml@chore/terraform-version-input
     permissions:
       id-token: write
       contents: read
@@ -38,5 +53,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.terraform-plan.outputs.tfplanExitCode == '2'
     with:
       working_dir: "terraform"
+      stack_name: smile-app-prod
       aws_oidc_role: ${{ vars.AWS_OIDC_ROLE_ARN }}
       aws_region: ap-southeast-2
+      # Must match the plan job's version so apply consumes the artifact with a compatible CLI.
+      terraform_version: "1.15.6"
+      init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"

--- a/docs/ci-deploy-enablement.md
+++ b/docs/ci-deploy-enablement.md
@@ -1,0 +1,106 @@
+# CI deploy enablement, scope of work
+
+Goal: get the `Smile Configuration Deployment` workflow (`.github/workflows/smile-application.yml`)
+to reliably plan on PRs and apply on merge to `main`, replacing local `terraform apply`.
+
+Status as of 2026-07-11: the workflow is `disabled_manually` and **has never successfully
+applied for this stack**. All real deploys to date have been local. Enabling it as-is would
+fail. This document scopes the work to make it actually deploy. It is analysis only, nothing
+here changes the pipeline yet.
+
+## How the pipeline is designed to work
+
+`smile-application.yml` is a thin caller of two reusable workflows in `aehrc/sparked-infrastructure`:
+
+- `template-terraform-plan.yml@main` runs on PRs (plan only) and on push to `main`.
+- `template-terraform-apply.yml@main` runs only on push to `main` when the plan reports changes
+  (`tfplanExitCode == 2`), and applies the exact plan artifact produced by the plan job.
+
+Good properties already in place:
+
+- AWS auth is OIDC (`vars.AWS_OIDC_ROLE_ARN = arn:aws:iam::471112546300:role/github-actions-eks-role`),
+  no static credentials.
+- Apply consumes the plan job's `main.tfplan` artifact, so there is no plan/apply drift.
+- Apply is intended to be gated by a GitHub Environment (`infra-apply`, "required reviewers").
+- Runners are self-hosted ARC (`arc-runner-set`) on the `sparkey` cluster, with a `CI_RUNNER`
+  repo-var escape hatch to fall back to `ubuntu-latest`.
+- Init does not use `-upgrade`; it respects the committed `.terraform.lock.hcl`.
+
+## Blockers (must fix before enabling)
+
+1. **Root workflow is out of sync with the template.** The template now requires a `stack_name`
+   input; `smile-application.yml` does not pass it, so the reusable-workflow call fails validation.
+   Fix (this repo): add `stack_name: smile-app-prod` to both job `with:` blocks.
+
+2. **CI cannot reach the state backend.** The `backend "s3"` block only sets `region` + `key`; the
+   **bucket** lives in `terraform/backend.hcl`, which is gitignored (`.gitignore:38`). The template
+   runs `terraform init ${{ inputs.init_args }}` and the root workflow passes no `init_args`.
+   Fix (this repo): add a repo variable (e.g. `TF_STATE_BUCKET`) and pass
+   `init_args: -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}"`.
+
+3. **CI has no variable values.** `terraform.tfvars` is gitignored (`.gitignore:14`); the required
+   vars `cdr_regcred_secret_arn`, `s3_bucket_name`, `smilecdr_iam_role_name` have no defaults.
+   The template passes no `-var-file`/`TF_VAR_*`. Plan fails on missing vars.
+   Note: none of these three are secrets (a Secrets Manager ARN, a bucket name, an IAM role name),
+   so repo variables are acceptable. `additional_args` is only consumed by the plan job; apply uses
+   the artifact, so the vars only need to be present at plan time.
+   Fix (this repo): add repo variables and pass
+   `additional_args: -var="s3_bucket_name=${{ vars.S3_BUCKET }}" -var="cdr_regcred_secret_arn=..." -var="smilecdr_iam_role_name=..."`.
+   Alternative (cleaner, cross-repo): have the reusable template fetch `backend.hcl` + `terraform.tfvars`
+   from SSM Parameter Store before init, so consumers pass nothing sensitive through workflow args.
+
+4. **CI Terraform is too old.** Both templates pin `terraform_version: '1.13.4'`; the v9.0.2 module
+   requires `>= 1.14.3` (we run 1.15.6 locally). `init` fails the version constraint.
+   Fix (cross-repo, `aehrc/sparked-infrastructure`): either bump the pinned version to a value that
+   satisfies `>= 1.14.3` (check the blast radius, all consumers of these templates) or, preferably,
+   add a `terraform_version` input (default kept, consumers override) and set it to `1.15.6` here.
+
+5. **The apply gate does not exist.** The GitHub Environment `infra-apply` is not configured on this
+   repo. GitHub auto-creates a missing environment on first use **without** protection rules, so the
+   apply would run ungated.
+   Fix: create the `infra-apply` environment with required reviewers before enabling apply.
+
+6. **OIDC role permissions unverified.** `github-actions-eks-role` must be able to run the FULL apply:
+   S3 state read/write + DynamoDB lock (if used), RDS, KMS, IAM, Secrets Manager, Lambda (invoke +
+   manage), Route53, and EKS describe/token. If it is EKS-scoped, apply fails partway.
+   Fix: review the role's policy against a real plan's resource set; expand if needed.
+
+## Secondary checks
+
+- `terraform fmt -check -recursive` is a hard gate. Fixed on this branch (was dirty on `main`).
+- `tflint --minimum-failure-severity=error` is a gate, run it locally against `terraform/` and clear
+  any error-severity findings.
+- Confirm the self-hosted ARC runner has egress to the S3 backend and AWS APIs and can assume the
+  OIDC role; otherwise set `CI_RUNNER=ubuntu-latest`.
+
+## Sequenced plan
+
+Phase 1, make plan-on-PR green (no apply risk):
+
+1. Update `smile-application.yml`: add `stack_name`, `init_args` (backend bucket), `additional_args` (vars).
+2. Add repo variables: `TF_STATE_BUCKET`, `S3_BUCKET`, `CDR_REGCRED_SECRET_ARN`, `SMILECDR_IAM_ROLE_NAME`.
+3. Resolve the Terraform version (blocker 4).
+4. Ensure `fmt` + `tflint` clean.
+5. Open a PR touching `terraform/**` or `module-config/**`; iterate until the plan job is green and
+   posts a plan comment. This validates backend + vars + version + lint end to end, with no apply.
+
+Phase 2, enable apply:
+
+6. Create the `infra-apply` environment with required reviewers.
+7. Verify the OIDC role can perform the full apply (blocker 6).
+8. `gh workflow enable smile-application.yml`.
+9. Merge a trivial no-op change; watch plan (exitcode 2) then the gated apply, approve, confirm it
+   applies cleanly and the service stays healthy. Keep a human watching the first real run.
+
+Phase 3, operationalize:
+
+10. Add branch protection requiring the plan check to pass before merge.
+11. Document the flow (PR = plan, merge = apply) in the README and retire the "apply locally" note.
+
+## Risks / watch-items
+
+- The Terraform-version fix is cross-repo and shared; verify other stacks still work.
+- Passing vars via `additional_args` puts their values in workflow logs (acceptable for these
+  non-secret values; revisit if any become sensitive).
+- The first apply-on-merge is the real test of role permissions and the runner, do it with a
+  trivial change, gated, watched, with the pre-apply snapshot pattern still available.

--- a/terraform/REMEDIATION.md
+++ b/terraform/REMEDIATION.md
@@ -1,0 +1,88 @@
+# Terraform Remediation Runbook
+
+Handoff runbook to get the Sparked Smile CDR terraform back to a clean, applyable,
+best-practice state, then apply to prod and re-enable CI deploy.
+
+Written 2026-07-10 from a session that diagnosed the drift by running a live `plan`.
+See also the project-memory note `deploy-pipeline-state`.
+
+## Goal / definition of done
+
+- `terraform plan` against prod shows **zero destroys and only intended in-place changes**.
+- Prod applied and healthy; the ingress 16 MiB body-size limit is codified (no longer a manual annotation).
+- The `Smile Configuration Deployment` workflow is re-enabled and the pinned config lands via a reviewed PR.
+
+## Locked decisions
+
+- **Module target: latest released tag `v9.2.0`** (currently pinned to the moving branch `terraform-module`, which drifted to module version 8.1.0; last successful apply was on 7.3.0).
+- **Keep `helm_chart_version = "7.1.0"`** for this pass. Fix the terraform-module drift only; do NOT also upgrade Smile CDR itself in the same change (one axis at a time).
+- **No non-prod/staging env.** Validate via careful `plan` review only.
+- **Brief downtime is acceptable** (server is used mainly during events).
+- **Local `terraform apply` until stable**, then move to the pipeline.
+- Take an Aurora snapshot before applying.
+
+## Known drift (from the plan on 2026-07-10)
+
+Baseline: `provider.tf` pinned kubernetes `< 3.0.0`, but the drifted module requires `>= 3.0.1`.
+After bumping k8s to v3 to init, `plan` = **17 add / 9 change / 16 destroy**, plus a hard error. The problem items:
+
+1. **Aurora engine DOWNGRADE** `14.20 -> 14.15`. The live DB auto-upgraded to 14.20 (`engine_version_actual` confirms); Aurora cannot downgrade. Must reconcile.
+2. **KMS secrets alias replacement** `alias/smile-secrets -> alias/smile-secrets-dff66d5832d6f1c8` (forces replacement).
+3. **`create_app_user` lambda invocations replaced** for every node (aucore, ereq, hl7au, audit, clustermgr, persistence, transaction) plus their `pg_user_db` `aws_secretsmanager_secret_version` resources.
+4. **kubernetes v3 provider error**: `Provider produced null object` for `module...data.kubernetes_resource.gateway["gateway-api"]`. The plan did not complete cleanly.
+5. The desired change (ingress `proxy-body-size: 16m`) DOES show correctly as an in-place `helm_release.smilecdr[0]` update, that part is fine.
+
+## Environment / prerequisites
+
+- terraform 1.15.6; AWS SSO admin creds, account `471112546300`, region `ap-southeast-2`.
+- `terraform/backend.hcl` and `terraform/terraform.tfvars` are present (real, gitignored). Backend state key: `infra/smile-app/prod.tfstate`.
+- Providers target the EKS cluster via module data sources (`module.smile_cdr_dependencies.eks_cluster.*`), so terraform ignores the local kubectl context. For direct `kubectl`, use `--context sparked-smile` (the repo hook's context warning is a false alarm for terraform).
+- The live serving ingress is `smile/smilecdr-scdr` (class `nginx`, host `smile.sparked-fhir.com`). The 16 MiB fix is currently a manual out-of-band annotation on it; it is also merged into `module-config/values-common.yaml` (PR #59).
+
+## Procedure
+
+### 0. Safety first
+- `aws rds create-db-cluster-snapshot` (or instance snapshot) of the Smile Aurora cluster; wait until `available`.
+- Confirm the `smilecdr-users-json` / DB-user secrets are recoverable.
+- Pick a low-usage window; expect brief downtime.
+
+### 1. Baseline branch + pin
+- `git checkout -b chore/terraform-remediation` off `main`.
+- In `terraform/main.tf`, change the module `source` ref from `?ref=terraform-module` to `?ref=v9.2.0`.
+- In `terraform/provider.tf`, set provider constraints to what v9.2.0 requires (expect kubernetes `>= 3.0.1, < 4.0.0`; helm already `>= 3.0.0`; aws as required). Read the module's `versions.tf` under `.terraform/modules/...` after init to confirm exact constraints.
+- Keep `helm_chart_version = "7.1.0"`.
+- `terraform init -upgrade -backend-config=backend.hcl`.
+
+### 2. Drive the plan to non-destructive
+Iterate `terraform plan` and resolve each problem item; the goal is zero destroy.
+
+- **engine_version**: find where v9.2.0 exposes the Aurora engine version (module var / rdsinstance submodule). Set it to `14.20` to match the live DB, or add `lifecycle { ignore_changes = [engine_version] }` if the module allows passthrough. Confirm the plan no longer shows a downgrade.
+- **KMS alias**: understand the new alias naming in v9.2.0 (the `-dff66d5832d6f1c8` suffix). Prefer a `moved {}` block or `terraform import` / `state mv` so the existing alias is retained rather than replaced (replacing the alias used for secrets is risky). If the module makes the suffix unavoidable, plan the secret re-encryption/rotation deliberately.
+- **create_app_user lambdas + pg_user_db secret versions**: determine the replacement trigger (likely `secret_string_wo_version` / input hash changes). Confirm whether re-running rotates live DB passwords that nodes depend on. If it does, coordinate: the nodes read DB creds from these secrets, so a rotation may need a node restart / users.json re-seed. If idempotent, accept.
+- **gateway-api data source null**: the repo `ingress_config.public` has no `ingressType`, so it defaults to `gatewayapi`, but the live ingress is nginx (`smilecdr-scdr`). Reconcile `ingress_config` to reality: set `ingressType = "nginx-ingress"` (and confirm this removes the gateway `kubernetes_resource` data source that errors under the v3 provider). This should also make the plan match the live nginx ingress instead of trying to stand up a gateway/ALB one.
+- For any remaining replace/destroy, use `moved {}` / `import` to align state with the new module's resource addresses without recreation.
+
+### 3. Codify the ingress body-size fix
+- Ensure the `default` (nginx) ingress carries `nginx.ingress.kubernetes.io/proxy-body-size: "16m"` from `values-common.yaml` (already merged) so that after apply the manual annotation is codified and the plan shows no ingress diff.
+
+### 4. Apply to prod (local)
+- Re-confirm the snapshot exists.
+- `terraform apply` the reviewed plan in the chosen window.
+- Verify: pods healthy; aucore + ereq FHIR endpoints return `metadata`; the anonymous size probe returns `403` under 16 MiB and `413` over; token flow works for `consultmed-ereq-backend` (client_credentials) and the smart_auth login flow.
+
+### 5. Stabilize, then re-enable the pipeline
+- Once plans are clean and applies are boring, commit the pinned-tag + provider + ingress_config changes and open a PR.
+- Re-enable the deploy workflow: `gh workflow enable smile-application.yml`. Note `terraform-apply` in that workflow only runs on `push` to `main` (not `workflow_dispatch`), so a merge to `main` is what triggers a real apply.
+
+## Rollback
+- If an apply goes wrong: restore Aurora from the pre-apply snapshot; revert the module `ref` to the previous state; re-apply the ingress `proxy-body-size` annotation manually if needed (`kubectl --context sparked-smile -n smile annotate ingress smilecdr-scdr nginx.ingress.kubernetes.io/proxy-body-size=16m --overwrite`).
+
+## Reusable verification probe (anonymous, non-persisting)
+```bash
+for kb in 1100 15000 17000; do
+  b=$((kb*1024))
+  python3 -c "import sys;sys.stdout.write('{\"resourceType\":\"Bundle\",\"type\":\"transaction\",\"_pad\":\"'+'x'*($b-60)+'\"}')" > /tmp/pb.json
+  curl -s -o /dev/null -w "${kb}KB -> %{http_code}\n" -m 120 -X POST -H "Content-Type: application/fhir+json" --data @/tmp/pb.json https://smile.sparked-fhir.com/ereq/fhir/DEFAULT
+done
+# Expect: 1100KB and 15000KB -> 403 (through nginx), 17000KB -> 413 (over 16 MiB cap)
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,7 +7,7 @@ module "smile_cdr_dependencies" {
   helm_chart_version     = "7.1.0"
 
 
-  helm_chart_values = [                                                                        #alpha order
+  helm_chart_values = [                                                                      #alpha order
     templatefile("../module-config/values-common.yaml", { s3_bucket = var.s3_bucket_name }), #core - required
     file("../module-config/simplified-multinode.yaml")
   ]

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -23,15 +23,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28.0, < 7.0.0"  # Module (v9.0.2) requires >= 6.28.0
+      version = ">= 6.28.0, < 7.0.0" # Module (v9.0.2) requires >= 6.28.0
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1.1, < 4.0.0"  # Module (v9.0.2) requires >= 3.1.1
+      version = ">= 3.1.1, < 4.0.0" # Module (v9.0.2) requires >= 3.1.1
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 3.0.1, < 4.0.0"  # Module (v9.0.2) requires >= 3.0.1
+      version = ">= 3.0.1, < 4.0.0" # Module (v9.0.2) requires >= 3.0.1
     }
   }
   backend "s3" {


### PR DESCRIPTION
## Summary

Phase 1 of enabling the `Smile Configuration Deployment` workflow: make **plan-on-PR** green. Zero apply risk, the apply job stays gated (push to `main` + plan-has-changes + `infra-apply` environment) and the workflow itself remains `disabled_manually` until Phase 2.

Scope and rationale are in `docs/ci-deploy-enablement.md`.

## Key finding: the reusable-template design can't work for this repo

`smile-application.yml` was a thin caller of reusable workflows in the **private** `aehrc/sparked-infrastructure`. Since this repo was made **public**, GitHub blocks a public repo from consuming a private repo's reusable workflows (`error parsing called workflow ... : workflow was not found`). That is why the workflow last succeeded in Dec 2025 (while this repo was private) and would fail if enabled today.

**Resolution: inline (vendor) the plan and apply steps directly into `smile-application.yml`**, mirroring `template-terraform-plan.yml` / `template-terraform-apply.yml`. No cross-repo call. Keep the inlined steps roughly in sync if those templates change.

## What changed

- **`smile-application.yml`**: self-contained `terraform-plan` (PRs) and `terraform-apply` (push to main, gated) jobs. Injects the gitignored state bucket via `-backend-config` and the three no-default vars via `-var` from repo variables (none are secrets). Terraform pinned `1.15.6` (module v9.0.2 needs >= 1.14.3). Runner defaults to `ubuntu-latest`; repo var `CI_RUNNER` overrides.
- **Repo variables added** (non-secret): `TF_STATE_BUCKET`, `S3_BUCKET`, `CDR_REGCRED_SECRET_ARN`, `SMILECDR_IAM_ROLE_NAME`.
- **`terraform/REMEDIATION.md`** added as a reference for the drift remediation already applied to prod.
- **`.github/workflows/_ci-plan-validation.yml`**: TEMPORARY plan-only mirror of the plan job, enabled so it runs on this PR (the real workflow is disabled). **Delete before merge.**

## Validation

The temporary workflow ran green on this PR and posted a plan comment. The plan is **not** a no-op: it shows `1 to change` (exit 2), a pre-existing drift where #60 (AU Patient Summary generator jar `0.1.0-alpha` -> `1.0.0`) was merged to main but its helm-release upgrade was never applied to prod. The first apply-on-merge (Phase 2) will roll that out.

## Not in this PR (Phase 2, needs approval)

Re-enabling the workflow, creating the `infra-apply` environment with required reviewers, deleting the temp validation workflow, and the first gated apply-on-merge.

## Note

`aehrc/sparked-infrastructure#27` (adds a `terraform_version` input to the templates) was merged. This repo no longer needs it (inlined), but it is harmless and useful for the private-repo consumers.