### PR TITLE
Gate Smile CDR terraform apply behind a manual confirmed dispatch (Phase 2)

### DIFF
--- a/.github/workflows/smile-application.yml
+++ b/.github/workflows/smile-application.yml
@@ -1,9 +1,18 @@
 name: 'Smile Configuration Deployment'
 
-# Plan on PRs, apply on push to main when the plan reports changes.
+# Plan on PRs and on push to main; apply only on a manual, confirmed dispatch.
+#
+# Apply gate: this repo lives in a free-plan org, which does not support branch
+# protection or environment required-reviewers on private repos (the branch
+# protection and environment protection-rule APIs both return an "upgrade the
+# billing plan" error). So apply is NOT auto-run on merge. Instead it runs only
+# via workflow_dispatch when the operator types APPLY, and only when the plan
+# reports changes. The effective gate is "who can Run this workflow and type
+# APPLY" (write access). Push-to-main runs plan only, for post-merge drift
+# visibility; it never applies.
 #
 # The steps are inlined rather than calling the reusable templates in
-# aehrc/sparked-infrastructure: that repo is private and this repo is public,
+# aehrc/sparked-infrastructure: that repo is private and this repo was public,
 # and GitHub does not allow a public repo to consume a private repo's reusable
 # workflows ("workflow was not found"). The step sequence mirrors
 # template-terraform-plan.yml / template-terraform-apply.yml; keep them roughly
@@ -24,7 +33,13 @@ on:
     paths:
       - 'module-config/**'
       - 'terraform/**'
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch:
+    inputs:
+      confirm_apply:
+        description: 'Type APPLY to run terraform apply after the plan. Leave blank for a plan-only dry run.'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   id-token: write      # request the OIDC JWT
@@ -147,11 +162,13 @@ jobs:
   terraform-apply:
     name: 'Terraform Apply'
     needs: [terraform-plan]
-    # Only apply on main branch pushes when the plan reported changes (exitcode == 2).
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.terraform-plan.outputs.tfplanExitCode == '2'
+    # Manual gate: apply runs only on a workflow_dispatch where the operator
+    # typed APPLY, and only when the plan reported changes (exitcode == 2).
+    # A plain dispatch (blank confirm_apply) or a push/PR is plan-only. There is
+    # no environment reviewer gate: the free org plan rejects environment
+    # protection rules on private repos (see the header comment).
+    if: github.event_name == 'workflow_dispatch' && inputs.confirm_apply == 'APPLY' && needs.terraform-plan.outputs.tfplanExitCode == '2'
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    # Gate: the infra-apply environment (required reviewers) must exist before enabling apply.
-    environment: infra-apply
     defaults:
       run:
         working-directory: terraform


### PR DESCRIPTION
## Summary

Phase 2 of enabling CI deploy for the Smile CDR terraform stack. Phase 1 (plan-on-PR, inlined, no cross-repo templates) is merged and validated green (#61).

This replaces **auto-apply-on-merge** with a **manual `workflow_dispatch` gate**, because the `aehrc` org is on GitHub's **free plan**: branch protection and environment required-reviewers are both unavailable on private repos (the branch-protection API and the environment protection-rule API each return an "upgrade the billing plan" error). An `infra-apply` reviewer environment therefore cannot gate anything.

## Changes to `smile-application.yml`

- Add a `workflow_dispatch` input `confirm_apply`. Apply runs **only** when the operator types `APPLY` **and** the plan reports changes (`exitcode == 2`). A blank dispatch is a plan-only dry run.
- Drop the push-to-main auto-apply condition. Push-to-main now runs **plan only** (post-merge drift visibility); it never applies.
- Remove the `environment: infra-apply` reference (a no-op gate on the free plan) and document that the gate is the manual, typed-confirmation dispatch.

Plan-on-PR is unchanged. The workflow stays `disabled_manually` until we deliberately enable it.

## First apply is not a no-op

The first confirmed apply will roll the already-merged-but-unapplied AU Patient Summary generator jar `0.1.0-alpha` -> `1.0.0` (#60) into the helm release (helm upgrade -> pod roll). It should be run with a human watching. Rollback: pre-apply Aurora snapshot `smile-smilecluster-preremediation-20260710`.

## Validation

- YAML parses; `actionlint` clean.