### PR TITLE
Pin ereq to the 0.1.0-alpha AUPS generator, aucore stays on 1.0.0

### DIFF
--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -6,6 +6,14 @@ cdrNodes:
   aucore:
     name: aucore
     enabled: true
+    # AU Patient Summary generator jar (consumed by ig_support.ips.generation_strategy_class
+    # below). aucore runs the current 1.0.0 release; ereq pins the older 0.1.0-alpha.
+    copyFiles:
+      customerlib:
+        sources:
+        - type: s3
+          bucket: ${s3_bucket} # Rendered from var.s3_bucket_name via templatefile() in terraform/main.tf
+          path: /smile/hapi-aups-generator-1.0.0.jar
     config:
       locked: false
       database: true
@@ -89,6 +97,15 @@ cdrNodes:
   hl7au:
     name: hl7au
     enabled: true
+    # hl7au does not run the AUPS generator, but it already carried the 1.0.0 jar
+    # under the previous global copyFiles. Keep it here so moving copyFiles per-node
+    # does not change hl7au's pod spec (avoids an unnecessary restart).
+    copyFiles:
+      customerlib:
+        sources:
+        - type: s3
+          bucket: ${s3_bucket} # Rendered from var.s3_bucket_name via templatefile() in terraform/main.tf
+          path: /smile/hapi-aups-generator-1.0.0.jar
     config:
       database: true
     modules:
@@ -144,6 +161,14 @@ cdrNodes:
   ereq:
     name: ereq
     enabled: true
+    # ereq pins the older 0.1.0-alpha AU Patient Summary generator jar (aucore runs 1.0.0),
+    # consumed by ig_support.ips.generation_strategy_class in the persistence config below.
+    copyFiles:
+      customerlib:
+        sources:
+        - type: s3
+          bucket: ${s3_bucket} # Rendered from var.s3_bucket_name via templatefile() in terraform/main.tf
+          path: /smile/hapi-aups-generator-0.1.0-alpha.jar
     config:
       locked: false
       database: true
@@ -205,6 +230,7 @@ cdrNodes:
            # Practitioner:identifier
            # Organization:identifier
            # Patient:identifier
+          ig_support.ips.generation_strategy_class: "au.org.hl7.fhir.ps.strategy.AupsGenerationStrategy"
           db.driver: POSTGRES_9_4
           db.url: jdbc:postgresql://#{env['EREQ_DB_URL']}:#{env['EREQ_DB_PORT']}/#{env['EREQ_DB_DATABASE']}?sslmode=require
           db.password: "#{env['EREQ_DB_PASS']}"

--- a/module-config/values-common.yaml
+++ b/module-config/values-common.yaml
@@ -66,13 +66,9 @@ secrets:
           subPath: users-json  # Mount only the users-json key as a file, not a directory
 
 
-copyFiles:
-  customerlib:
-    sources:
-    # Copies files recursively from S3 to the customerlib directory
-    - type: s3
-      bucket: ${s3_bucket}  # Rendered from var.s3_bucket_name via templatefile() in terraform/main.tf
-      path: /smile/hapi-aups-generator-1.0.0.jar
+# copyFiles is set per-node in simplified-multinode.yaml (aucore -> AUPS generator
+# 1.0.0, ereq -> 0.1.0-alpha) rather than globally, so each node gets its own
+# generator jar version on the customerlib classpath.
 
 
 ## @section Resources

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,9 +7,9 @@ module "smile_cdr_dependencies" {
   helm_chart_version     = "7.1.0"
 
 
-  helm_chart_values = [                                                                      #alpha order
-    templatefile("../module-config/values-common.yaml", { s3_bucket = var.s3_bucket_name }), #core - required
-    file("../module-config/simplified-multinode.yaml")
+  helm_chart_values = [                                                                            #alpha order
+    templatefile("../module-config/values-common.yaml", { s3_bucket = var.s3_bucket_name }),       #core - required
+    templatefile("../module-config/simplified-multinode.yaml", { s3_bucket = var.s3_bucket_name }) # per-node copyFiles reference the bucket
   ]
 
   helm_chart_mapped_files = [


### PR DESCRIPTION
## Summary

Run different AU Patient Summary generator jar versions per node: **aucore on 1.0.0**, **ereq on 0.1.0-alpha**.

Previously a single global `copyFiles` block staged `hapi-aups-generator-1.0.0.jar` on every node, but only aucore loaded it (`ig_support.ips.generation_strategy_class`). This moves `copyFiles` per-node so versions can differ, and enables AUPS generation on ereq against the older jar.

## Changes

- **`terraform/main.tf`** - render `simplified-multinode.yaml` via `templatefile()` (was `file()`) so per-node `copyFiles` can reference the state bucket via `${s3_bucket}`, matching `values-common.yaml`. The file has no `${`/`%{}` sequences, so templating is a no-op apart from the new variable.
- **`module-config/values-common.yaml`** - remove the global `copyFiles` block.
- **`module-config/simplified-multinode.yaml`**:
  - **aucore** - node-level `copyFiles` -> `hapi-aups-generator-1.0.0.jar` (same jar as before).
  - **ereq** - node-level `copyFiles` -> `hapi-aups-generator-0.1.0-alpha.jar`, plus `ig_support.ips.generation_strategy_class: au.org.hl7.fhir.ps.strategy.AupsGenerationStrategy` to actually run the generator.
  - **hl7au** - node-level `copyFiles` -> `hapi-aups-generator-1.0.0.jar`, preserving the jar it already carried under the global block so its pod spec does not change (no restart).

The `0.1.0-alpha` jar already exists in the state bucket (uploaded out-of-band, dated 2025-02-11); `copyFiles` references it directly rather than managing it in terraform.

## Plan / blast radius

`terraform plan` = `0 to add, 1 to change, 0 to destroy` (single in-place `helm_release` update). Expected pod impact:

- **ereq**: rolls (new jar + new config key). Intended.
- **aucore**: no roll (identical 1.0.0 init container, just relocated in values).
- **hl7au**: no roll (retains its existing 1.0.0 jar).

To be confirmed by watching the apply. Apply runs via the manual `workflow_dispatch` gate with a human watching.

## Follow-up notes

- ereq's AU PS package seeding is unchanged (jar-only enablement, per decision). Only `package-au-patient-summary-1.0.0.json` exists in-repo and is already mounted on all nodes via `mappedFiles`; if the 0.1.0 generator needs a different AU PS package version seeded, that is a separate change.