### PR TITLE
Bump aucore AUPS generator jar to 1.0.1

### DIFF
--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -7,13 +7,13 @@ cdrNodes:
     name: aucore
     enabled: true
     # AU Patient Summary generator jar (consumed by ig_support.ips.generation_strategy_class
-    # below). aucore runs the current 1.0.0 release; ereq pins the older 0.1.0-alpha.
+    # below). aucore runs the current 1.0.1 release; ereq pins the older 0.1.0-alpha.
     copyFiles:
       customerlib:
         sources:
         - type: s3
           bucket: ${s3_bucket} # Rendered from var.s3_bucket_name via templatefile() in terraform/main.tf
-          path: /smile/hapi-aups-generator-1.0.0.jar
+          path: /smile/hapi-aups-generator-1.0.1.jar
     config:
       locked: false
       database: true


### PR DESCRIPTION
Point aucore's `copyFiles` at `hapi-aups-generator-1.0.1.jar` to pick up the emptyReason fix from `sparked-fhir-operations` 1.0.1 (aehrc/sparked-fhir-operations#17).

## Why

aucore currently serves a `$summary` document with only the sections that have data and no `emptyReason`. The `emptyReason` / "all sixteen sections always appear" logic previously lived in a generator path that Smile CDR does not invoke (Smile drives its built-in IPS generator from `ig_support.ips.generation_strategy_class`). 1.0.1 moves that logic into the strategy's `postManipulateIpsBundle` hook, so it now applies under Smile.

## Scope

- aucore `copyFiles`: `hapi-aups-generator-1.0.0.jar` to `1.0.1.jar`.
- hl7au unchanged (does not run the generator; avoids a needless pod roll).
- ereq unchanged (deliberately pinned to `0.1.0-alpha`).

Expected terraform effect: a single in-place `helm_release` update rolling only the aucore pod, which re-copies the new jar from the state bucket at startup. The `1.0.1.jar` object is uploaded to the bucket before apply.