### PR TITLE
Add multitenancy ADR, strategy paper, and phased rollout plan

### DIFF
--- a/docs/adr/0001-partition-based-multitenancy.md
+++ b/docs/adr/0001-partition-based-multitenancy.md
@@ -57,11 +57,15 @@ Constraints accepted (verified against Smile CDR and HAPI FHIR documentation):
 - **Existing scripts hardcode DEFAULT** (`scripts/register_smart_client.py`, `scripts/manage_smart_users.py`, `module-config/smart-post-authorize.js`). They gain a tenant parameter as part of the rollout.
 - Users granted only a vendor tenant lose authenticated access to `DEFAULT`; they read shared data anonymously instead. This is a deliberate simplification.
 
-Risks:
+Risks (both historical defects were tested empirically in Phase 0 on 2026-07-13 and neither reproduces on 2025.11.R02; see the rollout plan's results table):
 
-- A historical HAPI FHIR defect (hapifhir/hapi-fhir#3396) allowed a write in one partition to overwrite a same-ID resource in another; a fix was merged but the exact fixed release is unconfirmed. The Phase 0 matrix tests this exact case on our version before any tenant is handed to a vendor.
-- The conditional-operation match-URL cache historically ignored partition ID (hapifhir/hapi-fhir#6767, fixed in HAPI FHIR 8.0/2025 timeframe). `match_url_cache.enabled: true` is set on `aucore`. The Phase 0 matrix tests conditional isolation; if it fails, the cache is disabled on partitioned nodes.
-- Smile CDR has no formal statement on some edge behaviours (for example anonymous users holding partition permissions). Phase 0 verifies empirically; a Smile support ticket is the escalation path for surprises.
+- A historical HAPI FHIR defect (hapifhir/hapi-fhir#3396) allowed a write in one partition to overwrite a same-ID resource in another. **Verified fixed on our version**: the colliding write is rejected with HTTP 409 and the original resource is untouched.
+- The conditional-operation match-URL cache historically ignored partition ID (hapifhir/hapi-fhir#6767). `match_url_cache.enabled: true` is set on `aucore`. **Verified isolated on our version**: a conditional update in one partition does not match an identifier that exists only in another.
+- Smile CDR has no formal statement on some edge behaviours (for example anonymous users holding partition permissions). Phase 0 verified the core access model empirically; a Smile support ticket is the escalation path for future surprises.
+
+## Verification
+
+The full access model was demonstrated live on the `ereq` node on 2026-07-13 with `scripts/multitenancy_phase0_tests.sh`: runtime tenant creation, anonymous denial on the new tenant, tenant-scoped read/write for a scoped user with hard 403s against DEFAULT, cross-partition reference blocking, ID-collision rejection without overwrite, conditional-update isolation, and clean teardown. Results are recorded in `docs/multitenancy-rollout-plan.md`.
 
 ## References
 

--- a/docs/adr/0001-partition-based-multitenancy.md
+++ b/docs/adr/0001-partition-based-multitenancy.md
@@ -1,0 +1,74 @@
+# ADR 0001: Partition-based multitenancy with a read-only DEFAULT tenant
+
+- **Status**: Proposed (requires DTR and Brett Esler sign-off per repository governance)
+- **Date**: 2026-07-13
+- **Deciders**: DTR, Brett Esler
+- **Technical scope**: Sparked Dev FHIR Server (`smile.sparked-fhir.com`), nodes `ereq` and `aucore`. The `hl7au` node is explicitly out of scope for this ADR.
+
+## Context
+
+The Sparked Dev FHIR Server runs Smile CDR 2025.11.R02 with FHIR data partitioning already enabled on every node:
+
+- `partitioning.enabled: true` and `partitioning.partition_selection_mode: REQUEST_TENANT` on the persistence module
+- `partitioning.tenant_identification_strategy: URL_BASED` on the FHIR endpoint module
+
+This is why all endpoint URLs carry a tenant segment today (`.../fhir/DEFAULT`). Only the built-in `DEFAULT` partition is in use, so the server is effectively single-tenant: all participants share one dataset.
+
+That shared dataset creates recurring friction, most visibly at connectathons and test events:
+
+1. Participants regularly ask for read/write access, especially for AU eRequesting medications workflows where placer/filler flows require creating and updating MedicationRequest, Task, and related resources.
+2. Participants want to load their own custom test data and read it back reliably. In the shared partition their data is visible to everyone, can conflict with other participants' data, and is removed whenever the shared dataset is cleared between events.
+3. Granting write access to the shared data means any participant can modify or delete the curated AU Core test data that other participants (and read-only demonstrations) depend on.
+
+Smile CDR's permission model is partition-aware but coarse: `FHIR_ACCESS_PARTITION_NAME` gates which partitions a session may touch (it "includes both read and write operations"), while read/write authority comes from separate global permissions (`FHIR_ALL_READ`, `FHIR_ALL_WRITE`). Permissions combine additively, so a single session cannot natively hold "read-only on partition A, read-write on partition B". There are no partition-scoped read or write permissions in the current release.
+
+## Decision
+
+Adopt partition-per-tenant multitenancy with a read-only shared tenant, enforced through the existing permission model. No new modules, no custom interceptors, and no server restarts are required for tenant lifecycle operations.
+
+1. **Tenants are Smile CDR partitions.** Each vendor or connectathon scenario that needs write access receives its own partition (for example `VENDOR-ACME`, `SCENARIO-EREQ-MEDS`), created with the `$partition-management-create-partition` operation. Tenant URLs follow automatically from the existing URL-based tenant identification (`.../ereq/fhir/VENDOR-ACME`).
+2. **DEFAULT becomes read-only for non-admin principals.** The curated shared dataset stays in `DEFAULT`. Anonymous read access to `DEFAULT` is unchanged. `FHIR_ALL_WRITE` and `FHIR_TRANSACTION` are removed from every non-admin principal that holds `FHIR_ACCESS_PARTITION_NAME: DEFAULT`. Test data loading continues through admin credentials.
+3. **Vendor principals are scoped to their tenant.** A vendor's users and OIDC clients receive `FHIR_ALL_READ`, `FHIR_ALL_WRITE`, `FHIR_TRANSACTION`, and `FHIR_ACCESS_PARTITION_NAME: <TENANT>` without `DEFAULT` in the argument list. Write isolation then follows from partition access: the session cannot write to `DEFAULT` because it cannot access `DEFAULT` at all while authenticated. Shared data remains available to the same application through anonymous reads of `DEFAULT`, and conformance and terminology resources (StructureDefinition, ValueSet, CodeSystem, SearchParameter, IG packages) are non-partitionable in HAPI FHIR, always live in the default partition, and are served to every tenant automatically.
+4. **Rollout is staged one node at a time**: rehearsal and first real tenants on `ereq`, then `aucore`. See `docs/multitenancy-rollout-plan.md`.
+5. **Partition definitions move to a git-tracked seed file** (`partitioning.seed.file`) once the tenant list stabilises. Initial tenants are created through the admin API to avoid pod restarts during events.
+6. **A consent-service script is explicitly deferred.** If a future requirement demands a single authenticated session with read access to `DEFAULT` and write access to a tenant, the documented fallback is a small JavaScript consent service on the FHIR endpoint that rejects write verbs when the request tenant is `DEFAULT`. It is not part of this decision.
+
+## Alternatives considered
+
+- **Status quo (shared DEFAULT, per-user write grants).** Rejected: write access for one participant endangers the curated data for all, and custom test data cannot coexist cleanly.
+- **Consent-script-enforced read-only DEFAULT with mixed grants.** Workable and documented (Smile CDR Consent Service), but adds custom code where pure configuration suffices. Kept as the fallback for mixed-session requirements.
+- **Separate Smile CDR instance or node per vendor.** Strong isolation but multiplies infrastructure cost, IG deployment effort, and operational surface. Partitions provide the needed isolation on existing infrastructure.
+- **REQUEST_HEADER partition selection.** Supports multi-partition reads but is flagged early-access by Smile, and changing selection mode is a disruptive reconfiguration. URL-based REQUEST_TENANT is the mainline supported path and is already live.
+
+## Consequences
+
+Positive:
+
+- Vendors and scenarios get genuine read/write sandboxes; the shared dataset becomes tamper-proof for non-admins.
+- Tenant lifecycle (create, clear, delete) is a runtime admin operation with no restarts and no effect on other tenants.
+- Per-tenant data clearing replaces all-or-nothing expunges between events.
+
+Constraints accepted (verified against Smile CDR and HAPI FHIR documentation):
+
+- **One global resource-ID pool.** Client-assigned IDs are unique across the whole server, not per partition. Tenants loading standard test bundles with fixed IDs can collide with `DEFAULT` or each other. Mitigation: tenant data loads use server-assigned IDs or tenant-prefixed IDs; behaviour is verified in the Phase 0 test matrix.
+- **Cross-partition references are blocked** (`cross_partition_reference_mode: NOT_ALLOWED`, the default). Tenant data must be self-contained; a tenant cannot reference the shared patients in `DEFAULT` by local reference. This is the correct isolation posture and matches the "load your own data" use case.
+- **No cross-tenant search.** URL-based mode has no all-partitions query (`_ALL` is supported only for `$reindex`). Administrative sweeps iterate per tenant.
+- **Subscriptions match only within their own partition** by default. Scenario subscriptions are created inside the scenario tenant.
+- **Existing scripts hardcode DEFAULT** (`scripts/register_smart_client.py`, `scripts/manage_smart_users.py`, `module-config/smart-post-authorize.js`). They gain a tenant parameter as part of the rollout.
+- Users granted only a vendor tenant lose authenticated access to `DEFAULT`; they read shared data anonymously instead. This is a deliberate simplification.
+
+Risks:
+
+- A historical HAPI FHIR defect (hapifhir/hapi-fhir#3396) allowed a write in one partition to overwrite a same-ID resource in another; a fix was merged but the exact fixed release is unconfirmed. The Phase 0 matrix tests this exact case on our version before any tenant is handed to a vendor.
+- The conditional-operation match-URL cache historically ignored partition ID (hapifhir/hapi-fhir#6767, fixed in HAPI FHIR 8.0/2025 timeframe). `match_url_cache.enabled: true` is set on `aucore`. The Phase 0 matrix tests conditional isolation; if it fails, the cache is disabled on partitioned nodes.
+- Smile CDR has no formal statement on some edge behaviours (for example anonymous users holding partition permissions). Phase 0 verifies empirically; a Smile support ticket is the escalation path for surprises.
+
+## References
+
+- Smile CDR: Partitioning and Multitenancy, https://smilecdr.com/docs/fhir_repository/partitioning.html
+- Smile CDR: FHIR Storage Partitioning configuration, https://smilecdr.com/docs/configuration_categories/fhir_storage_partitioning.html
+- Smile CDR: FHIR Endpoint Partitioning configuration, https://smilecdr.com/docs/configuration_categories/fhir_endpoint_partitioning.html
+- Smile CDR: Roles and Permissions, https://smilecdr.com/docs/security/roles_and_permissions.html
+- Smile CDR: Consent Service, https://smilecdr.com/docs/security/consent_service.html
+- HAPI FHIR: Partitioning, https://hapifhir.io/hapi-fhir/docs/server_jpa_partitioning/partitioning.html
+- Related documents: `docs/multitenancy-strategy.md`, `docs/multitenancy-rollout-plan.md`

--- a/docs/multitenancy-rollout-plan.md
+++ b/docs/multitenancy-rollout-plan.md
@@ -1,0 +1,81 @@
+# Multitenancy rollout plan
+
+Implementation plan for [ADR 0001](adr/0001-partition-based-multitenancy.md). Read the [strategy paper](multitenancy-strategy.md) for the motivation.
+
+**Scope**: nodes `ereq` and `aucore` on the Sparked Dev FHIR Server. The `hl7au` node is untouched by this plan.
+
+**Key property of this rollout**: phases 0 to 2 involve **no config file changes, no pod restarts, and no downtime**. Partitions, users, and permissions are runtime data managed through the admin APIs. The only eventual restart is the optional move to a git-tracked partition seed file in Phase 3.
+
+## Phase 0: rehearsal on ereq (go/no-go gate)
+
+Create a temporary partition `MTTEST` (id 9001) on `ereq`, run the test matrix below with admin credentials plus one throwaway scoped user, then delete everything. A ready-to-run script performs all steps including cleanup.
+
+### Test matrix
+
+| # | Test | Expected | Why it matters |
+|---|------|----------|----------------|
+| T1 | `$partition-management-list-partitions` | 200, lists DEFAULT | Confirms partition management operations are enabled on our build |
+| T2 | Create partition MTTEST via `$partition-management-create-partition` | 200 | Tenant provisioning works at runtime, no restart |
+| T3 | Anonymous `GET /MTTEST/Patient` | 401 or 403 | New tenants are private by default; ANONYMOUS only holds DEFAULT access |
+| T4 | Admin `PUT /MTTEST/Patient/...` | 201 | Tenant URL routing works end to end |
+| T5 | Anonymous `GET /DEFAULT/Patient` still 200; tenant resource invisible via DEFAULT | 200 / 404 | Existing consumers unaffected; no cross-tenant leakage |
+| T6 | Same client-assigned ID PUT into MTTEST then DEFAULT | Two independent resources, neither overwritten | Guards against the hapi-fhir #3396 overwrite defect on our version |
+| T7 | Observation in MTTEST with local reference to a DEFAULT patient | 4xx rejection | Confirms cross-partition reference blocking (isolation posture) |
+| T8 | Conditional PUT in DEFAULT matching an identifier that exists only in MTTEST | 201 create in DEFAULT; MTTEST resource untouched at v1 | Guards against the match-URL-cache defect (hapi-fhir #6767); `match_url_cache` is enabled on aucore |
+| T9 | Scoped user (`FHIR_ALL_READ` + `FHIR_ALL_WRITE` + `FHIR_ACCESS_PARTITION_NAME: MTTEST`): read/write MTTEST, read and write DEFAULT | 200/201 in MTTEST; 403 on both DEFAULT calls | Proves the entire access model of ADR 0001 with zero custom code |
+| T10 | Cleanup: delete test resources, test user, MTTEST partition | 200s; tenant URL then 4xx | Tenant teardown is clean and total |
+
+**Go/no-go**: T3, T6, T7, T8, and T9 must all behave as expected before any vendor tenant is created. A T6 or T8 failure is a stop: raise with Smile support and re-evaluate (mitigations: server-assigned IDs only, disable the match URL cache).
+
+### Phase 0 results
+
+_To be filled in when the matrix is executed against ereq._
+
+## Phase 1: first real tenants on ereq
+
+1. **Naming convention**: `VENDOR-<NAME>` for vendor sandboxes, `SCENARIO-<TRACK>` for shared scenario workspaces (uppercase, hyphenated, stable). Partition IDs allocated from 100 upwards, recorded in this repo.
+2. Create 2 to 3 pilot tenants via `$partition-management-create-partition`.
+3. **Script changes** (this repo):
+   - `scripts/register_smart_client.py`: replace the `DEFAULT_PARTITION` constant usage with a `--tenant` argument (default `DEFAULT`) so clients can be scoped to a vendor tenant.
+   - `scripts/manage_smart_users.py`: same `--tenant` argument; vendor-scoped users get read/write authorities with `FHIR_ACCESS_PARTITION_NAME: <TENANT>` and no `DEFAULT` access.
+   - `module-config/smart-post-authorize.js`: derive the FHIR base for `fhirUser` and launch context from the request audience instead of the hardcoded `.../aucore/fhir/DEFAULT` fallback, so tokens minted for tenant endpoints carry tenant-correct URLs.
+   - Issue template `05-smart-app-registration.yml`: add a tenant field.
+4. **Test data**: tenant loads use server-assigned IDs or tenant-prefixed IDs (single global ID pool). Publish a self-contained starter bundle (patients, practitioners, organizations) that vendors can POST into their tenant, since local references to DEFAULT data are blocked by design.
+5. Onboard pilot vendors; their feedback gates Phase 2.
+
+## Phase 2: make DEFAULT read-only on ereq
+
+1. Inventory principals holding `FHIR_ACCESS_PARTITION_NAME: DEFAULT` together with any write permission (`FHIR_ALL_WRITE`, `FHIR_WRITE_ALL_OF_TYPE`, `FHIR_TRANSACTION`). Current known set: `DevTester`, `placer`, `filler` (users.json), read-write connectathon users, and read-write OIDC clients.
+2. Remove write authorities from those principals, or re-scope them to a tenant. `ADMIN` (`ROLE_SUPERUSER`) keeps write for curated data loads.
+3. Update the seeded `users.json` secret so the read-only shape survives reseeding.
+4. Verify: authenticated `POST /DEFAULT/...` returns 403 for every non-admin principal; anonymous and authenticated reads unchanged; test-data loader (admin) still works.
+5. Update participant docs (`connectathon-participant-handout.md`, `SMART-APP-REGISTRATION.md`, Confluence entry): DEFAULT is read-only, writes happen in your tenant.
+
+## Phase 3: aucore, then hardening
+
+1. Repeat phases 1 and 2 on `aucore` (aucore also serves AU Core read-only traffic, so DEFAULT read-only is a smaller behavioural change there).
+2. Move partition definitions to a git-tracked seed file (`partitioning.seed.file` pointing at a `fhir-partitions.json` in `module-config/`), deployed like package configs. This is the one step that requires a pod roll; schedule it outside events.
+3. Add a "Tenant request" offering to the service catalogue (issue template + semi-automated workflow, following the SMART registration pattern).
+4. Revisit deferred items: consent-service script for mixed-session access, `subscription.cross_partition_enabled` (currently false; scenario subscriptions live inside their tenant so the default stands), per-tenant bulk export permissions.
+
+## Rollback
+
+- Phases 0 and 1 are purely additive: delete the tenant partitions and vendor principals and the server is bit-identical to today.
+- Phase 2 rollback is restoring the previous authorities on the affected principals (they are enumerated in the inventory from step 1 and version-controlled in the users.json secret).
+- No step in phases 0 to 2 touches the DEFAULT data, the schema, or module configuration.
+
+## Operational runbook (post-rollout)
+
+| Operation | How |
+|---|---|
+| Create tenant | `POST {base}/DEFAULT/$partition-management-create-partition` (admin) |
+| Grant a client/user a tenant | `FHIR_ACCESS_PARTITION_NAME: <TENANT>` via registration scripts |
+| Clear a tenant | Delete/expunge scoped to the tenant URL |
+| Delete tenant | Clear it, then `$partition-management-delete-partition` |
+| List tenants | `$partition-management-list-partitions` |
+
+## Governance
+
+- ADR 0001 approval (DTR, Brett Esler) is required before Phase 1.
+- Phase 0 is a test-only rehearsal on the dev server with full cleanup and may run ahead of approval to inform the ADR evidence section.
+- The `hl7au` node and the HL7-hosted reference environments are out of scope; any future extension to them follows the elevated `needs:hl7-approval` process.

--- a/docs/multitenancy-rollout-plan.md
+++ b/docs/multitenancy-rollout-plan.md
@@ -29,7 +29,22 @@ Create a temporary partition `MTTEST` (id 9001) on `ereq`, run the test matrix b
 
 ### Phase 0 results
 
-_To be filled in when the matrix is executed against ereq._
+Executed 2026-07-13 against `ereq` (Smile CDR 2025.11.R02) using `scripts/multitenancy_phase0_tests.sh`. **All go/no-go tests passed.** Full cleanup verified: tenant URL returns 404 after partition deletion and anonymous DEFAULT reads are unchanged.
+
+| # | Result | Observed |
+|---|--------|----------|
+| T1 | Note | `$partition-management-list-partitions` returned HTTP 400 on this build; create/delete operations work, so tenant inventory uses the admin console or repo records instead |
+| T2 | Pass | Partition created at runtime, HTTP 200, tenant URL live immediately |
+| T3 | Pass | Anonymous request to the new tenant rejected with HTTP 403 |
+| T4 | Pass | Admin write via tenant URL, HTTP 201 |
+| T5 | Pass | Anonymous DEFAULT read unchanged (200); tenant resource invisible via DEFAULT (404) |
+| T6 | Pass | Same client-assigned ID in a second partition rejected with HTTP 409 (HAPI-0550/HAPI-0825 client-assigned ID constraint); the first partition's resource untouched at v1. Confirms the global ID pool constraint and confirms the hapi-fhir #3396 cross-partition overwrite defect does not reproduce on 2025.11.R02: the write is safely rejected, nothing is overwritten |
+| T7 | Pass | Cross-partition local reference rejected with HTTP 400 (HAPI-1094 target not found in partition) |
+| T8 | Pass | Conditional PUT in DEFAULT with an identifier existing only in MTTEST performed a create (201, new resource) rather than a cross-partition update; the MTTEST resource remained readable afterwards. The hapi-fhir #6767 match-URL-cache defect does not reproduce |
+| T9 | Pass | Scoped user (write authorities + `FHIR_ACCESS_PARTITION_NAME: MTTEST` only): read and write in MTTEST succeeded (200/201); read and write against DEFAULT both rejected with 403. This is the entire ADR 0001 access model working with zero custom code |
+| T10 | Pass | All test resources deleted (200s); partition deleted (200); tenant URL 404 afterwards. One caveat: the user-management API does not support DELETE (405), so the throwaway user was disabled and locked with authorities stripped instead. Vendor offboarding should plan for disable rather than delete |
+
+Consequences folded into this plan: tenant loads must use server-assigned or tenant-prefixed IDs (T6 makes collisions a hard 409, not a corruption risk), and the runbook's "list tenants" row uses the admin console.
 
 ## Phase 1: first real tenants on ereq
 
@@ -72,7 +87,8 @@ _To be filled in when the matrix is executed against ereq._
 | Grant a client/user a tenant | `FHIR_ACCESS_PARTITION_NAME: <TENANT>` via registration scripts |
 | Clear a tenant | Delete/expunge scoped to the tenant URL |
 | Delete tenant | Clear it, then `$partition-management-delete-partition` |
-| List tenants | `$partition-management-list-partitions` |
+| List tenants | Admin console (Partition Management); the list operation returned 400 on 2025.11.R02 |
+| Offboard a principal | Disable and lock the account, strip authorities (user DELETE is unsupported, returns 405) |
 
 ## Governance
 

--- a/docs/multitenancy-strategy.md
+++ b/docs/multitenancy-strategy.md
@@ -1,0 +1,80 @@
+# Multitenancy on the Sparked Dev FHIR Server: strategy paper
+
+**Audience**: Sparked program team. **Companion documents**: [ADR 0001](adr/0001-partition-based-multitenancy.md) (the decision record) and the [rollout plan](multitenancy-rollout-plan.md) (the how and when).
+
+## The problem we keep hitting
+
+Every test event generates the same two requests:
+
+1. **"Can we get write access?"** Especially from eRequesting participants: medications workflows are inherently write-heavy (create the MedicationRequest, claim the Task, update the status, post the result). Read-only access lets a vendor watch, not participate.
+2. **"Can we load our own test data?"** Vendors arrive with curated datasets for their product demos and want to read them back reliably during the event.
+
+Today everything lives in one shared dataset (the `DEFAULT` tenant). That forces a bad trade-off:
+
+- If we grant write access, any participant can modify or delete the curated AU Core test data every other participant depends on. One stray `DELETE` or a badly built transaction Bundle degrades the event for everyone.
+- If we do not, vendors cannot exercise the workflows they came to test, and custom data loading turns into "email the admins and hope".
+- Either way, custom data mixed into the shared pool collides with other vendors' data and is wiped whenever we clear the server between events.
+
+We have been splitting the difference with per-user read-only and read-write permission levels, which protects nothing (read-write users can still write over shared data) and satisfies nobody.
+
+## The proposal in one paragraph
+
+Give each vendor (or connectathon scenario) its own **tenant**: a private slice of the same server, with its own URL. The shared curated dataset stays where it is and becomes **read-only for everyone except admins**. A vendor gets full read/write inside their tenant and cannot touch anyone else's. Nothing else changes: same server, same IGs, same validation, same SMART auth, same terminology, zero new infrastructure.
+
+```
+https://smile.sparked-fhir.com/ereq/fhir/DEFAULT            shared curated data (read-only)
+https://smile.sparked-fhir.com/ereq/fhir/VENDOR-ACME        Acme's sandbox (their read/write)
+https://smile.sparked-fhir.com/ereq/fhir/SCENARIO-EREQ-MEDS medications track workspace
+```
+
+## Why this is cool for connectathons
+
+- **eRequesting medications, actually end-to-end.** A scenario tenant can host the full placer/filler medications flow: participants create MedicationRequests, claim and update Tasks, post statuses, fire subscriptions, all with real writes, without any risk to the shared dataset. Multiple vendor pairs can run the same scenario in parallel tenants without tripping over each other's Tasks.
+- **Bring-your-own test data.** A vendor loads their dataset into their tenant on day one and it is still there, untouched, on day three. Clearing between events becomes surgical: wipe scenario tenants, keep vendor tenants, never disturb `DEFAULT`.
+- **The shared data finally becomes trustworthy.** `DEFAULT` turns into a stable, tamper-proof reference dataset. Demos and validation runs against it are reproducible because nobody can write to it.
+- **Negative testing becomes safe.** Participants can test deletes, overwrites, and malformed updates in their own tenant. Today that class of testing is effectively banned.
+- **Instant provisioning.** Creating a tenant is one admin API call. No restart, no deployment, no downtime, no effect on running traffic. We can provision a new vendor mid-event in under a minute.
+- **Fits the existing service catalogue.** "Request a tenant" becomes a normal semi-automated offering, like SMART client registration is today.
+
+## Why this is cool for Sparked beyond connectathons
+
+- **Vendor evaluation sandboxes.** Long-running private workspaces for vendors building against AU Core / AU eRequesting, on infrastructure we already operate.
+- **Parallel IG testing.** A tenant per test campaign (for example a draft IG's test data) that can be created and destroyed freely.
+- **A governance story for write access.** Today "can I have write access" is a judgement call with shared blast radius. Under this model the answer is simply "yes, here is your tenant", and the blast radius is the requester's own data.
+
+## Why the lift is small
+
+This is the part that usually surprises people: **multitenancy is already switched on.** The server has run Smile CDR's URL-based tenant mode since day one; that is literally why every URL ends in `/DEFAULT`. Every user and client already carries a partition permission. What remains is:
+
+1. Create partitions for tenants (runtime admin operation).
+2. Register vendor users/clients scoped to their tenant instead of `DEFAULT` (a parameter change in scripts we already have).
+3. Remove write permissions from the principals that can currently write to `DEFAULT` (config of existing users).
+4. One small edit to the SMART post-authorize script so token context uses the right tenant URL.
+
+No new modules, no interceptors, no schema changes, no data migration, no downtime.
+
+## What it costs (honestly)
+
+- **Tenant data must be self-contained.** A tenant cannot reference the shared `DEFAULT` patients by local reference (cross-partition references are blocked by design). Vendors load their own patient set, or we publish a copyable starter bundle. For scenario tenants this is arguably a feature: each run is hermetic.
+- **Resource IDs are unique server-wide, not per tenant.** Two tenants cannot both hold `Patient/example` with client-assigned IDs. Tenant loads should use server-assigned IDs or a tenant prefix; the test-data tooling can do the prefixing.
+- **Authenticated vendor sessions do not see `DEFAULT`.** Vendors read the shared data anonymously (it is public read today and stays that way). If a workflow ever genuinely needs one authenticated session spanning both, there is a documented one-script fallback (consent service), deferred until proven necessary.
+- **No cross-tenant queries.** Admin sweeps iterate tenants one by one.
+- **Ops must learn about ten lines of new runbook**: create tenant, grant tenant, clear tenant, delete tenant.
+
+## What stays exactly the same
+
+- All existing `DEFAULT` URLs, for every current client and script.
+- Anonymous read of the shared data.
+- IGs, profiles, validation, terminology: conformance resources are served to all tenants from one shared store, so every tenant validates against the same AU Core / eRequesting profiles automatically.
+- SMART on FHIR auth flows and the registration process (with one added "tenant" field).
+- Infrastructure, cost, monitoring, backup.
+
+## Rollout at a glance
+
+Staged one node at a time, rehearsal first, with an explicit go/no-go test matrix before any vendor is onboarded. `ereq` first (where the demand is), then `aucore`. `DEFAULT` becomes read-only only after tenants are proven working. Full detail, test matrix, and rollback story: [multitenancy-rollout-plan.md](multitenancy-rollout-plan.md).
+
+## The ask
+
+1. Review and approve [ADR 0001](adr/0001-partition-based-multitenancy.md) (DTR and Brett Esler are the deciders).
+2. Nominate the first two or three vendors/scenarios for the `ereq` pilot.
+3. After the pilot event, decide whether to promote the model to `aucore`.

--- a/scripts/multitenancy_phase0_tests.sh
+++ b/scripts/multitenancy_phase0_tests.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Phase 0 multitenancy rehearsal against the ereq node (Sparked Dev FHIR Server).
+# Creates a temporary MTTEST partition, verifies isolation properties, then cleans up.
+# Admin credentials are fetched from AWS Secrets Manager at runtime and kept in memory only.
+set -u
+
+BASE="https://smile.sparked-fhir.com/ereq/fhir"
+ADMINJSON="https://smile.sparked-fhir.com/ereq/admin-json"
+PART_ID=9001
+PART_NAME="MTTEST"
+TESTUSER="mt-phase0-vendor"
+RESULTS="${PHASE0_RESULTS:-$(dirname "$0")/phase0-results.md}"
+
+ADMIN_PASS=$(aws secretsmanager get-secret-value --secret-id smilecdr-user-passwords --query SecretString --output text | jq -r '."smilecdr-admin-password"')
+if [ -z "$ADMIN_PASS" ] || [ "$ADMIN_PASS" = "null" ]; then echo "FATAL: could not fetch admin password"; exit 1; fi
+TESTUSER_PASS=$(openssl rand -base64 18 | tr -d '/+=' )
+
+echo "# Phase 0 results ($(date -u '+%Y-%m-%d %H:%M UTC'))" > "$RESULTS"
+note() { echo "$1" | tee -a "$RESULTS"; }
+
+# curl helpers: capture status + body, never echo credentials
+acurl() { curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/fhir+json" "$@"; }
+ucurl() { curl -s --max-time 30 -u "$TESTUSER:$TESTUSER_PASS" -H "Content-Type: application/fhir+json" "$@"; }
+anoncurl() { curl -s --max-time 30 -H "Content-Type: application/fhir+json" "$@"; }
+
+note ""
+note "## T1: list partitions (before)"
+T1=$(acurl -o /tmp/t1.json -w "%{http_code}" "$BASE/DEFAULT/\$partition-management-list-partitions")
+note "- HTTP $T1"
+[ "$T1" = "200" ] && note "- names: $(jq -r '[.parameter[]?.part[]? | select(.name=="name") | .valueCode // .valueString] | join(", ")' /tmp/t1.json 2>/dev/null)"
+
+note ""
+note "## T2: create $PART_NAME partition (id $PART_ID)"
+T2=$(acurl -o /tmp/t2.json -w "%{http_code}" -X POST "$BASE/DEFAULT/\$partition-management-create-partition" -d "{\"resourceType\":\"Parameters\",\"parameter\":[{\"name\":\"id\",\"valueInteger\":$PART_ID},{\"name\":\"name\",\"valueCode\":\"$PART_NAME\"},{\"name\":\"description\",\"valueString\":\"Phase 0 multitenancy rehearsal partition (temporary, safe to delete)\"}]}")
+note "- HTTP $T2"
+[ "$T2" != "200" ] && [ "$T2" != "201" ] && note "- body: $(head -c 500 /tmp/t2.json)"
+
+note ""
+note "## T3: anonymous access to new tenant is blocked"
+T3=$(anoncurl -o /tmp/t3.json -w "%{http_code}" "$BASE/$PART_NAME/Patient?_count=1")
+note "- anonymous GET /$PART_NAME/Patient: HTTP $T3 (expect 401/403)"
+
+note ""
+note "## T4: admin can write into $PART_NAME via tenant URL"
+T4=$(acurl -o /tmp/t4.json -w "%{http_code}" -X PUT "$BASE/$PART_NAME/Patient/mt-phase0-scratch1" -d '{"resourceType":"Patient","id":"mt-phase0-scratch1","identifier":[{"system":"http://example.org/mt-phase0","value":"scratch-1"}],"name":[{"family":"ScratchTenant","given":["Original"]}]}')
+note "- PUT /$PART_NAME/Patient/mt-phase0-scratch1: HTTP $T4 (expect 201)"
+[ "$T4" != "200" ] && [ "$T4" != "201" ] && note "- body: $(head -c 700 /tmp/t4.json)"
+
+note ""
+note "## T5: anonymous read of DEFAULT unchanged"
+T5=$(anoncurl -o /dev/null -w "%{http_code}" "$BASE/DEFAULT/Patient?_count=1")
+note "- anonymous GET /DEFAULT/Patient: HTTP $T5 (expect 200)"
+T5b=$(anoncurl -o /dev/null -w "%{http_code}" "$BASE/DEFAULT/Patient/mt-phase0-scratch1")
+note "- anonymous GET /DEFAULT/Patient/mt-phase0-scratch1: HTTP $T5b (expect 404, resource lives only in $PART_NAME)"
+
+note ""
+note "## T6: client-assigned ID collision across partitions"
+T6pre=$(acurl -o /dev/null -w "%{http_code}" "$BASE/DEFAULT/Patient/mt-phase0-collision")
+note "- precheck DEFAULT/Patient/mt-phase0-collision: HTTP $T6pre (expect 404)"
+T6a=$(acurl -o /tmp/t6a.json -w "%{http_code}" -X PUT "$BASE/$PART_NAME/Patient/mt-phase0-collision" -d '{"resourceType":"Patient","id":"mt-phase0-collision","name":[{"family":"InScratch"}]}')
+note "- PUT /$PART_NAME/Patient/mt-phase0-collision: HTTP $T6a"
+T6b=$(acurl -o /tmp/t6b.json -w "%{http_code}" -X PUT "$BASE/DEFAULT/Patient/mt-phase0-collision" -d '{"resourceType":"Patient","id":"mt-phase0-collision","name":[{"family":"InDefault"}]}')
+note "- PUT /DEFAULT/Patient/mt-phase0-collision (same ID, different partition): HTTP $T6b"
+[ "$T6b" != "200" ] && [ "$T6b" != "201" ] && note "- body: $(head -c 700 /tmp/t6b.json)"
+T6c=$(acurl -o /tmp/t6c.json -w "%{http_code}" "$BASE/$PART_NAME/Patient/mt-phase0-collision")
+T6d=$(acurl -o /tmp/t6d.json -w "%{http_code}" "$BASE/DEFAULT/Patient/mt-phase0-collision")
+note "- after: $PART_NAME copy HTTP $T6c family=$(jq -r '.name[0].family // "n/a"' /tmp/t6c.json 2>/dev/null) v=$(jq -r '.meta.versionId // "n/a"' /tmp/t6c.json 2>/dev/null); DEFAULT copy HTTP $T6d family=$(jq -r '.name[0].family // "n/a"' /tmp/t6d.json 2>/dev/null) v=$(jq -r '.meta.versionId // "n/a"' /tmp/t6d.json 2>/dev/null)"
+
+note ""
+note "## T7: cross-partition local reference is rejected"
+T7a=$(acurl -o /dev/null -w "%{http_code}" -X PUT "$BASE/DEFAULT/Patient/mt-phase0-reftarget" -d '{"resourceType":"Patient","id":"mt-phase0-reftarget","name":[{"family":"RefTarget"}]}')
+note "- setup PUT /DEFAULT/Patient/mt-phase0-reftarget: HTTP $T7a"
+T7b=$(acurl -o /tmp/t7b.json -w "%{http_code}" -X POST "$BASE/$PART_NAME/Observation" -d '{"resourceType":"Observation","status":"final","code":{"coding":[{"system":"http://loinc.org","code":"8867-4"}]},"subject":{"reference":"Patient/mt-phase0-reftarget"}}')
+note "- POST /$PART_NAME/Observation referencing DEFAULT patient: HTTP $T7b (expect 4xx rejection)"
+note "- body: $(jq -r '.issue[0].diagnostics // empty' /tmp/t7b.json 2>/dev/null | head -c 400)"
+
+note ""
+note "## T8: conditional update does not match across partitions"
+T8a=$(acurl -o /tmp/t8a.json -w "%{http_code}" -X PUT "$BASE/DEFAULT/Patient?identifier=http://example.org/mt-phase0|scratch-1" -d '{"resourceType":"Patient","identifier":[{"system":"http://example.org/mt-phase0","value":"scratch-1"}],"name":[{"family":"ConditionalInDefault"}]}')
+note "- conditional PUT in DEFAULT with identifier that only exists in $PART_NAME: HTTP $T8a (expect 201 create, NOT cross-partition update)"
+T8loc=$(acurl -s -o /dev/null -w "%{http_code}" "$BASE/$PART_NAME/Patient/mt-phase0-scratch1")
+T8v=$(acurl -s "$BASE/$PART_NAME/Patient/mt-phase0-scratch1" | jq -r '.meta.versionId // "n/a"; .name[0].family // "n/a"' | paste -sd' ' -)
+note "- $PART_NAME/Patient/mt-phase0-scratch1 after: HTTP $T8loc, versionId+family: $T8v (expect v1 ScratchTenant, untouched)"
+T8id=$(jq -r '.id // empty' /tmp/t8a.json 2>/dev/null)
+note "- created-in-DEFAULT id: ${T8id:-unknown}"
+
+note ""
+note "## T9: scoped vendor-style user (write $PART_NAME, no DEFAULT access)"
+T9a=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/json" -o /tmp/t9a.json -w "%{http_code}" -X POST "$ADMINJSON/user-management/ereq/local_security" -d "{\"username\":\"$TESTUSER\",\"password\":\"$TESTUSER_PASS\",\"givenName\":\"MTTest\",\"familyName\":\"Phase0\",\"authorities\":[{\"permission\":\"ROLE_FHIR_CLIENT\"},{\"permission\":\"FHIR_CAPABILITIES\"},{\"permission\":\"FHIR_ALL_READ\"},{\"permission\":\"FHIR_ALL_WRITE\"},{\"permission\":\"FHIR_TRANSACTION\"},{\"permission\":\"FHIR_ACCESS_PARTITION_NAME\",\"argument\":\"$PART_NAME\"}]}")
+T9pid=$(jq -r '.pid // empty' /tmp/t9a.json 2>/dev/null)
+note "- create user: HTTP $T9a (pid: ${T9pid:-unknown})"
+if [ "$T9a" = "200" ] || [ "$T9a" = "201" ]; then
+  T9b=$(ucurl -o /dev/null -w "%{http_code}" "$BASE/$PART_NAME/Patient?_count=1")
+  note "- vendor GET /$PART_NAME/Patient: HTTP $T9b (expect 200)"
+  T9c=$(ucurl -o /tmp/t9c.json -w "%{http_code}" -X POST "$BASE/$PART_NAME/Patient" -d '{"resourceType":"Patient","name":[{"family":"VendorWrite"}]}')
+  T9cid=$(jq -r '.id // empty' /tmp/t9c.json 2>/dev/null)
+  note "- vendor POST /$PART_NAME/Patient: HTTP $T9c (expect 201, id ${T9cid:-unknown})"
+  T9d=$(ucurl -o /dev/null -w "%{http_code}" "$BASE/DEFAULT/Patient?_count=1")
+  note "- vendor GET /DEFAULT/Patient: HTTP $T9d (expect 403, no DEFAULT partition access)"
+  T9e=$(ucurl -o /dev/null -w "%{http_code}" -X POST "$BASE/DEFAULT/Patient" -d '{"resourceType":"Patient","name":[{"family":"ShouldFail"}]}')
+  note "- vendor POST /DEFAULT/Patient: HTTP $T9e (expect 403)"
+fi
+
+note ""
+note "## Cleanup"
+for u in "$PART_NAME/Patient/mt-phase0-scratch1" "$PART_NAME/Patient/mt-phase0-collision" "DEFAULT/Patient/mt-phase0-collision" "DEFAULT/Patient/mt-phase0-reftarget"; do
+  C=$(acurl -o /dev/null -w "%{http_code}" -X DELETE "$BASE/$u"); note "- DELETE $u: HTTP $C"
+done
+if [ -n "${T8id:-}" ]; then C=$(acurl -o /dev/null -w "%{http_code}" -X DELETE "$BASE/DEFAULT/Patient/$T8id"); note "- DELETE DEFAULT/Patient/$T8id (conditional-create artifact): HTTP $C"; fi
+if [ -n "${T9cid:-}" ]; then C=$(acurl -o /dev/null -w "%{http_code}" -X DELETE "$BASE/$PART_NAME/Patient/$T9cid"); note "- DELETE $PART_NAME/Patient/$T9cid (vendor write artifact): HTTP $C"; fi
+if [ -n "${T9pid:-}" ]; then
+  C=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -o /tmp/t9del.json -w "%{http_code}" -X DELETE "$ADMINJSON/user-management/ereq/local_security/$T9pid")
+  note "- DELETE test user pid $T9pid: HTTP $C"
+  if [ "$C" != "200" ] && [ "$C" != "204" ]; then
+    C2=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/json" -o /dev/null -w "%{http_code}" -X PUT "$ADMINJSON/user-management/ereq/local_security/$T9pid" -d "{\"username\":\"$TESTUSER\",\"accountDisabled\":true,\"accountLocked\":true,\"authorities\":[]}")
+    note "- user delete unsupported; disabled+locked instead: HTTP $C2"
+  fi
+fi
+CDEL=$(acurl -o /tmp/cdel.json -w "%{http_code}" -X POST "$BASE/DEFAULT/\$partition-management-delete-partition" -d "{\"resourceType\":\"Parameters\",\"parameter\":[{\"name\":\"id\",\"valueInteger\":$PART_ID}]}")
+note "- delete $PART_NAME partition: HTTP $CDEL"
+[ "$CDEL" != "200" ] && note "- body: $(head -c 500 /tmp/cdel.json)"
+
+note ""
+note "## Post-cleanup verification"
+P1=$(anoncurl -o /dev/null -w "%{http_code}" "$BASE/$PART_NAME/Patient?_count=1")
+note "- anonymous GET /$PART_NAME/Patient after partition delete: HTTP $P1 (expect 4xx, tenant gone)"
+P2=$(anoncurl -o /dev/null -w "%{http_code}" "$BASE/DEFAULT/Patient?_count=1")
+note "- anonymous GET /DEFAULT/Patient: HTTP $P2 (expect 200)"
+echo ""
+echo "Done. Results in $RESULTS"


### PR DESCRIPTION
## Summary

Proposes partition-per-tenant multitenancy with a read-only DEFAULT tenant, motivated by recurring connectathon requests for write access (especially AU eRequesting medications flows) and for loading custom test data without touching the shared dataset.

Partitioning is already enabled on every node (URL_BASED / REQUEST_TENANT, hence the /DEFAULT URLs), so tenant provisioning is a runtime admin operation: no config file change, no restart, no data migration.

## Contents

- **ADR 0001** (docs/adr/0001-partition-based-multitenancy.md): the decision record. Tenants are partitions; vendor principals are scoped to their tenant via FHIR_ACCESS_PARTITION_NAME without DEFAULT; DEFAULT becomes read-only for non-admins. Requires DTR and Brett Esler sign-off.
- **Strategy paper** (docs/multitenancy-strategy.md): the pitch and the honest cost list.
- **Rollout plan** (docs/multitenancy-rollout-plan.md): Phase 0 rehearsal with a go/no-go test matrix, then ereq, then DEFAULT read-only, then aucore. Phases 0 to 2 need no restarts. Includes rollback story and runbook.
- **Phase 0 test script** (scripts/multitenancy_phase0_tests.sh): self-cleaning rehearsal against ereq.

## Verification

**Phase 0 was executed against ereq on 2026-07-13 and all go/no-go tests passed.** Highlights:

- Runtime tenant creation works; new tenants reject anonymous access (403)
- The scoped-user access model works with zero custom code: read/write inside the tenant, hard 403 on both read and write against DEFAULT
- Cross-partition ID collisions are rejected with 409 and nothing is overwritten (hapi-fhir #3396 does not reproduce on 2025.11.R02)
- Conditional updates do not match identifiers in other partitions (hapi-fhir #6767 does not reproduce)
- Cross-partition local references are blocked (400)
- Full cleanup verified: all test resources and the temporary partition deleted, throwaway user disabled and locked (user DELETE returns 405 on this build)

Detailed results table is in the rollout plan.

## Out of scope

The hl7au node and HL7-hosted reference environments are untouched.