### PR TITLE
Tenant-scoped registration tooling, SMART callback fix, and ereq pilot records

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
+++ b/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
@@ -103,6 +103,21 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: tenant
+    attributes:
+      label: Tenant (optional)
+      description: |
+        The tenant (data partition) your client should be scoped to.
+        Leave blank for the shared `DEFAULT` tenant, which is **read-only** for participant clients.
+        If you need write access (loading your own test data, eRequesting placer/filler flows),
+        request a vendor or scenario tenant here, e.g. `VENDOR-ACME` or `SCENARIO-EREQ-MEDS`.
+        Your FHIR base URL becomes `https://smile.sparked-fhir.com/<node>/fhir/<TENANT>`.
+        If the tenant does not exist yet, we create it as part of this request.
+      placeholder: "VENDOR-ACME"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/docs/adr/0001-partition-based-multitenancy.md
+++ b/docs/adr/0001-partition-based-multitenancy.md
@@ -27,7 +27,7 @@ Smile CDR's permission model is partition-aware but coarse: `FHIR_ACCESS_PARTITI
 Adopt partition-per-tenant multitenancy with a read-only shared tenant, enforced through the existing permission model. No new modules, no custom interceptors, and no server restarts are required for tenant lifecycle operations.
 
 1. **Tenants are Smile CDR partitions.** Each vendor or connectathon scenario that needs write access receives its own partition (for example `VENDOR-ACME`, `SCENARIO-EREQ-MEDS`), created with the `$partition-management-create-partition` operation. Tenant URLs follow automatically from the existing URL-based tenant identification (`.../ereq/fhir/VENDOR-ACME`).
-2. **DEFAULT becomes read-only for non-admin principals.** The curated shared dataset stays in `DEFAULT`. Anonymous read access to `DEFAULT` is unchanged. `FHIR_ALL_WRITE` and `FHIR_TRANSACTION` are removed from every non-admin principal that holds `FHIR_ACCESS_PARTITION_NAME: DEFAULT`. Test data loading continues through admin credentials.
+2. **DEFAULT becomes read-only for participant principals.** The curated shared dataset stays in `DEFAULT`. Anonymous read access to `DEFAULT` is unchanged. `FHIR_ALL_WRITE` and `FHIR_TRANSACTION` are removed from participant principals (connectathon users and vendor clients) that hold `FHIR_ACCESS_PARTITION_NAME: DEFAULT`. Team-internal accounts (`ADMIN`, `DevTester`, `placer`, `filler`) retain read/write on the nodes they exist on: they are operated by the Sparked team and are the mechanism for curating the shared dataset (test data loads, IG seeding checks, placer/filler reference flows).
 3. **Vendor principals are scoped to their tenant.** A vendor's users and OIDC clients receive `FHIR_ALL_READ`, `FHIR_ALL_WRITE`, `FHIR_TRANSACTION`, and `FHIR_ACCESS_PARTITION_NAME: <TENANT>` without `DEFAULT` in the argument list. Write isolation then follows from partition access: the session cannot write to `DEFAULT` because it cannot access `DEFAULT` at all while authenticated. Shared data remains available to the same application through anonymous reads of `DEFAULT`, and conformance and terminology resources (StructureDefinition, ValueSet, CodeSystem, SearchParameter, IG packages) are non-partitionable in HAPI FHIR, always live in the default partition, and are served to every tenant automatically.
 4. **Rollout is staged one node at a time**: rehearsal and first real tenants on `ereq`, then `aucore`. See `docs/multitenancy-rollout-plan.md`.
 5. **Partition definitions move to a git-tracked seed file** (`partitioning.seed.file`) once the tenant list stabilises. Initial tenants are created through the admin API to avoid pod restarts during events.
@@ -44,7 +44,7 @@ Adopt partition-per-tenant multitenancy with a read-only shared tenant, enforced
 
 Positive:
 
-- Vendors and scenarios get genuine read/write sandboxes; the shared dataset becomes tamper-proof for non-admins.
+- Vendors and scenarios get genuine read/write sandboxes; the shared dataset becomes tamper-proof for participants (only team-operated accounts can modify it).
 - Tenant lifecycle (create, clear, delete) is a runtime admin operation with no restarts and no effect on other tenants.
 - Per-tenant data clearing replaces all-or-nothing expunges between events.
 

--- a/docs/multitenancy-demo.md
+++ b/docs/multitenancy-demo.md
@@ -1,0 +1,129 @@
+# Multitenancy demo: ereq pilot walkthrough
+
+A guided demo of partition-based multitenancy on the `ereq` node, as rolled out per
+[ADR 0001](adr/0001-partition-based-multitenancy.md) and the [rollout plan](multitenancy-rollout-plan.md).
+Every command below was executed and verified on 2026-07-13/14 against the live server.
+
+## What exists after the pilot rollout
+
+| Thing | Value |
+|---|---|
+| Scenario tenant | `SCENARIO-EREQ-MEDS` (partition id 100) at `https://smile.sparked-fhir.com/ereq/fhir/SCENARIO-EREQ-MEDS` |
+| Vendor tenant | `VENDOR-DEMO` (partition id 101) at `https://smile.sparked-fhir.com/ereq/fhir/VENDOR-DEMO` |
+| Demo users | `demo-placer`, `demo-filler` (scoped to SCENARIO-EREQ-MEDS), `demo-vendor` (scoped to VENDOR-DEMO); all read-write inside their tenant, no DEFAULT access |
+| Scenario data | Self-contained medications flow: Patient, Practitioner, Organization, MedicationRequest (AMT 23551011000036108, Amoxicillin 500 mg capsule), and a fulfil Task that demo-filler has driven requested to in-progress to completed |
+| DEFAULT tenant | Read-only for participants; team accounts (ADMIN, DevTester, placer, filler) unchanged |
+
+Demo user passwords are held by the Sparked team (not in this repo). Set them as
+environment variables before running the walkthrough:
+
+```bash
+export DEMO_PLACER_PASS='...'
+export DEMO_FILLER_PASS='...'
+export DEMO_VENDOR_PASS='...'
+BASE=https://smile.sparked-fhir.com/ereq/fhir
+```
+
+## The pitch, in six commands
+
+**1. The shared data is still there, public, unchanged:**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "$BASE/DEFAULT/Patient?_count=1"        # 200
+```
+
+**2. But tenants are private. Anonymous (and other tenants) get 403:**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "$BASE/SCENARIO-EREQ-MEDS/Patient?_count=1"   # 403
+```
+
+**3. A scenario participant has full read/write inside the scenario tenant.**
+The medications flow is already loaded; show the completed dispense Task:
+
+```bash
+curl -s -u "demo-placer:$DEMO_PLACER_PASS" \
+  "$BASE/SCENARIO-EREQ-MEDS/Task/task-demo-dispense" | jq '{status, owner, focus}'
+# status: completed, owner: Demo Filler (pharmacy), focus: MedicationRequest/mr-demo-amoxicillin
+```
+
+Live-write moment: have demo-placer create a second MedicationRequest on the spot:
+
+```bash
+curl -s -u "demo-placer:$DEMO_PLACER_PASS" -H "Content-Type: application/fhir+json" \
+  -o /dev/null -w "%{http_code}\n" -X POST "$BASE/SCENARIO-EREQ-MEDS/MedicationRequest" \
+  -d '{"resourceType":"MedicationRequest","status":"active","intent":"order",
+       "medicationCodeableConcept":{"coding":[{"system":"http://snomed.info/sct",
+       "code":"23551011000036108","display":"Amoxicillin 500 mg capsule"}]},
+       "subject":{"reference":"Patient/pat-demo-wang"}}'    # 201
+```
+
+**4. The same participant cannot touch the shared data, read or write:**
+
+```bash
+curl -s -u "demo-placer:$DEMO_PLACER_PASS" -o /dev/null -w "%{http_code}\n" \
+  "$BASE/DEFAULT/Patient?_count=1"                                               # 403
+curl -s -u "demo-placer:$DEMO_PLACER_PASS" -H "Content-Type: application/fhir+json" \
+  -o /dev/null -w "%{http_code}\n" -X POST "$BASE/DEFAULT/Patient" \
+  -d '{"resourceType":"Patient"}'                                                # 403
+```
+
+**5. Tenants cannot see each other.** The vendor sandbox user is blind to the scenario tenant:
+
+```bash
+curl -s -u "demo-vendor:$DEMO_VENDOR_PASS" -o /dev/null -w "%{http_code}\n" \
+  "$BASE/SCENARIO-EREQ-MEDS/Patient?_count=1"                                    # 403
+curl -s -u "demo-vendor:$DEMO_VENDOR_PASS" -o /dev/null -w "%{http_code}\n" \
+  "$BASE/VENDOR-DEMO/Patient?_count=1"                                           # 200
+```
+
+**6. Provisioning a new tenant is one API call, no restart, no deployment**
+(admin credentials; the pods have not restarted throughout this entire rollout):
+
+```bash
+curl -s -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/fhir+json" \
+  -X POST "$BASE/DEFAULT/\$partition-management-create-partition" \
+  -d '{"resourceType":"Parameters","parameter":[
+        {"name":"id","valueInteger":102},
+        {"name":"name","valueCode":"VENDOR-NEWCO"},
+        {"name":"description","valueString":"NewCo sandbox"}]}'
+```
+
+## Talking points
+
+- Everything above is **pure configuration**: no custom interceptors, no new modules,
+  no schema changes. Partitioning was already enabled (the `/DEFAULT` in every URL);
+  the pilot added tenants and scoped permissions.
+- The medications flow answers the most common connectathon request: **real write
+  access for eRequesting placer/filler workflows**, without risking the curated data.
+- Custom test data now has a home: a vendor loads a self-contained bundle into their
+  tenant and it survives shared-data clears between events.
+- Conformance content (AU Core / eRequesting profiles, terminology) is served to every
+  tenant from the shared store automatically, so validation behaves identically in
+  every tenant.
+- Rollout was staged exactly as the plan prescribes: rehearsal with a disposable
+  tenant and a go/no-go matrix (all passed), then pilot tenants, then participant
+  write removal on DEFAULT. aucore follows after sign-off.
+
+## Registering real vendors (post-demo)
+
+```bash
+# A vendor user scoped to their own tenant
+python scripts/manage_smart_users.py --node ereq --username acme-dev-01 \
+  --permissions read-write --tenant VENDOR-ACME
+
+# A backend service client scoped to their tenant
+python scripts/register_smart_client.py --node ereq --client-type backend-service \
+  --client-id acme-loader --scopes "system/*.*" --tenant VENDOR-ACME
+```
+
+The SMART registration issue template now has a Tenant field, so requests arrive
+with this information.
+
+## Rollback
+
+- Demo tenants: delete resources then `$partition-management-delete-partition`
+  (ids 100, 101). Demo users: disable and lock via the admin console or API.
+- Participant write removal: before-state snapshots of every changed principal are
+  retained by the team; each is a single PUT to restore.
+- The DEFAULT tenant, team accounts, aucore, and hl7au were not modified.

--- a/docs/multitenancy-rollout-plan.md
+++ b/docs/multitenancy-rollout-plan.md
@@ -58,12 +58,14 @@ Consequences folded into this plan: tenant loads must use server-assigned or ten
 4. **Test data**: tenant loads use server-assigned IDs or tenant-prefixed IDs (single global ID pool). Publish a self-contained starter bundle (patients, practitioners, organizations) that vendors can POST into their tenant, since local references to DEFAULT data are blocked by design.
 5. Onboard pilot vendors; their feedback gates Phase 2.
 
-## Phase 2: make DEFAULT read-only on ereq
+## Phase 2: make DEFAULT read-only for participants on ereq
 
-1. Inventory principals holding `FHIR_ACCESS_PARTITION_NAME: DEFAULT` together with any write permission (`FHIR_ALL_WRITE`, `FHIR_WRITE_ALL_OF_TYPE`, `FHIR_TRANSACTION`). Current known set: `DevTester`, `placer`, `filler` (users.json), read-write connectathon users, and read-write OIDC clients.
-2. Remove write authorities from those principals, or re-scope them to a tenant. `ADMIN` (`ROLE_SUPERUSER`) keeps write for curated data loads.
-3. Update the seeded `users.json` secret so the read-only shape survives reseeding.
-4. Verify: authenticated `POST /DEFAULT/...` returns 403 for every non-admin principal; anonymous and authenticated reads unchanged; test-data loader (admin) still works.
+Scope decision (2026-07-13): team-internal accounts (`ADMIN`, `DevTester`, `placer`, `filler`) stay read/write on the nodes they exist on; they are the curation mechanism for the shared dataset. Phase 2 applies only to participant principals.
+
+1. Inventory participant principals holding `FHIR_ACCESS_PARTITION_NAME: DEFAULT` together with any write permission (`FHIR_ALL_WRITE`, `FHIR_WRITE_ALL_OF_TYPE`, `FHIR_TRANSACTION`): read-write connectathon users (`connectathon-user-*`) and read-write OIDC clients (`connectathon-app-*`, `connectathon-backend-*`, vendor-registered clients).
+2. Remove write authorities from those principals, or re-scope them to a tenant. Record the before state for rollback.
+3. The seeded `users.json` secret is unchanged in this phase (it contains only team-internal accounts, which keep their permissions).
+4. Verify: authenticated `POST /DEFAULT/...` returns 403 for every participant principal; anonymous and authenticated reads unchanged; team accounts (`ADMIN`, `DevTester`, `placer`, `filler`) and the test-data loader still write.
 5. Update participant docs (`connectathon-participant-handout.md`, `SMART-APP-REGISTRATION.md`, Confluence entry): DEFAULT is read-only, writes happen in your tenant.
 
 ## Phase 3: aucore, then hardening

--- a/docs/multitenancy-rollout-plan.md
+++ b/docs/multitenancy-rollout-plan.md
@@ -68,6 +68,17 @@ Scope decision (2026-07-13): team-internal accounts (`ADMIN`, `DevTester`, `plac
 4. Verify: authenticated `POST /DEFAULT/...` returns 403 for every participant principal; anonymous and authenticated reads unchanged; team accounts (`ADMIN`, `DevTester`, `placer`, `filler`) and the test-data loader still write.
 5. Update participant docs (`connectathon-participant-handout.md`, `SMART-APP-REGISTRATION.md`, Confluence entry): DEFAULT is read-only, writes happen in your tenant.
 
+## Execution log
+
+- **2026-07-13**: Phase 0 executed on ereq, all go/no-go tests passed (results table above).
+- **2026-07-13/14**: Phases 1 and 2 executed on ereq with zero pod restarts:
+  - Tenants created: `SCENARIO-EREQ-MEDS` (id 100), `VENDOR-DEMO` (id 101).
+  - Demo principals created with the new tenant-scoped tooling: `demo-placer`, `demo-filler` (SCENARIO-EREQ-MEDS), `demo-vendor` (VENDOR-DEMO).
+  - A validated, self-contained medications scenario (Patient, Practitioner, Organization, MedicationRequest with AMT 23551011000036108, fulfil Task) was loaded by demo-placer and driven to completion by demo-filler, demonstrating the full placer/filler write flow inside a tenant.
+  - Participant write removal on ereq DEFAULT: `FHIR_ALL_WRITE` and `FHIR_TRANSACTION` stripped from users `ILYA`, `MICHAEL.OSBORNE`, `PATIENT-DASHBOARD` (before-state snapshots retained). No OIDC client on the ereq node carried write permissions, so no client changes were needed.
+  - Deferred: `connectathon-backend-02` holds `FHIR_ALL_WRITE` on DEFAULT but is registered on the **aucore** node; it is handled in Phase 3 with the rest of aucore.
+  - See `docs/multitenancy-demo.md` for the verified demo walkthrough.
+
 ## Phase 3: aucore, then hardening
 
 1. Repeat phases 1 and 2 on `aucore` (aucore also serves AU Core read-only traffic, so DEFAULT read-only is a smaller behavioural change there).

--- a/docs/multitenancy-strategy.md
+++ b/docs/multitenancy-strategy.md
@@ -19,7 +19,7 @@ We have been splitting the difference with per-user read-only and read-write per
 
 ## The proposal in one paragraph
 
-Give each vendor (or connectathon scenario) its own **tenant**: a private slice of the same server, with its own URL. The shared curated dataset stays where it is and becomes **read-only for everyone except admins**. A vendor gets full read/write inside their tenant and cannot touch anyone else's. Nothing else changes: same server, same IGs, same validation, same SMART auth, same terminology, zero new infrastructure.
+Give each vendor (or connectathon scenario) its own **tenant**: a private slice of the same server, with its own URL. The shared curated dataset stays where it is and becomes **read-only for participants** (only team-operated accounts can modify it). A vendor gets full read/write inside their tenant and cannot touch anyone else's. Nothing else changes: same server, same IGs, same validation, same SMART auth, same terminology, zero new infrastructure.
 
 ```
 https://smile.sparked-fhir.com/ereq/fhir/DEFAULT            shared curated data (read-only)

--- a/module-config/smart-post-authorize.js
+++ b/module-config/smart-post-authorize.js
@@ -26,9 +26,24 @@ function onTokenGenerating(theUserSession, theAuthorizationRequestDetails) {
         return;
     }
 
-    // getAudience() can return null for standalone launch — use fixed base as fallback
-    var audience = theAuthorizationRequestDetails.getAudience()
-        || "https://smile.sparked-fhir.com/aucore/fhir/DEFAULT";
+    // The audience is the FHIR base the app is authorizing against and, with
+    // URL-based multitenancy, carries the tenant segment (e.g. .../fhir/VENDOR-A).
+    // fhirUser and launch-context URLs below are built from it so tokens minted
+    // for a tenant endpoint reference resources at that tenant's base.
+    // getAudience() can return null for standalone launch; fall back to the
+    // whitelisted "aud" request parameter, then to the shared DEFAULT base.
+    var audience = theAuthorizationRequestDetails.getAudience();
+    if (!audience) {
+        var audParams = theAuthorizationRequestDetails.getRequestParameters();
+        if (audParams) {
+            audience = audParams.get("aud");
+        }
+    }
+    if (!audience) {
+        audience = "https://smile.sparked-fhir.com/aucore/fhir/DEFAULT";
+    }
+    // Normalise trailing slashes: URLs are built as audience + "/Practitioner/..."
+    audience = ("" + audience).replace(/\/+$/, "");
     var ctx;
 
     // getLaunch() is the dedicated accessor; fall back to the whitelisted request

--- a/scripts/manage_smart_users.py
+++ b/scripts/manage_smart_users.py
@@ -96,7 +96,8 @@ DEFAULT_PARTITION = "DEFAULT"
 # Permission Presets
 # =============================================================================
 
-def build_authorities(permission_level: str = "read-only") -> List[Dict]:
+def build_authorities(permission_level: str = "read-only",
+                      tenant: str = DEFAULT_PARTITION) -> List[Dict]:
     """Build SmileCDR authorities for a user based on a permission level preset.
 
     These authorities determine what the user can do when they log in and
@@ -105,11 +106,15 @@ def build_authorities(permission_level: str = "read-only") -> List[Dict]:
 
     Args:
         permission_level: One of "read-only", "read-write", or "superuser".
+        tenant: Partition name(s) the user may access (comma-separated for
+                multiple). Partition access gates both reads and writes, so a
+                read-write user scoped to a vendor tenant cannot touch DEFAULT
+                at all (see docs/adr/0001-partition-based-multitenancy.md).
     """
     authorities = [
         {"permission": "ROLE_FHIR_CLIENT"},
         {"permission": "FHIR_CAPABILITIES"},
-        {"permission": "FHIR_ACCESS_PARTITION_NAME", "argument": DEFAULT_PARTITION},
+        {"permission": "FHIR_ACCESS_PARTITION_NAME", "argument": tenant},
         {"permission": "FHIR_ALL_READ"},
     ]
 
@@ -137,6 +142,7 @@ def build_user_payload(
     permission_level: str = "read-only",
     practitioner_id: Optional[str] = None,
     patient_id: Optional[str] = None,
+    tenant: str = DEFAULT_PARTITION,
 ) -> Dict:
     """Build the JSON payload for creating a SmileCDR user.
 
@@ -150,6 +156,7 @@ def build_user_payload(
         practitioner_id: FHIR Practitioner resource ID for launch context
                          (e.g., "guthrie-aaron"). Used for EHR launch.
         patient_id: FHIR Patient resource ID for default patient launch context.
+        tenant: Partition name(s) the user may access (comma-separated).
     """
     payload = {
         "username": username,
@@ -161,7 +168,7 @@ def build_user_payload(
         "systemUser": False,
         "serviceAccount": False,
         "external": False,
-        "authorities": build_authorities(permission_level),
+        "authorities": build_authorities(permission_level, tenant=tenant),
     }
 
     if email:
@@ -358,7 +365,8 @@ class SmartUserManager:
                       family_name: str = "", email: str = "",
                       permission_level: str = "read-only",
                       practitioner_id: Optional[str] = None,
-                      patient_id: Optional[str] = None) -> UserResult:
+                      patient_id: Optional[str] = None,
+                      tenant: str = DEFAULT_PARTITION) -> UserResult:
         """Create a single user by arguments."""
         payload = build_user_payload(
             username=username,
@@ -369,6 +377,7 @@ class SmartUserManager:
             permission_level=permission_level,
             practitioner_id=practitioner_id,
             patient_id=patient_id,
+            tenant=tenant,
         )
         return self.create_user(payload)
 
@@ -407,6 +416,7 @@ class SmartUserManager:
                 permission_level=user_def.get("permissionLevel", "read-only"),
                 practitioner_id=user_def.get("practitionerId"),
                 patient_id=user_def.get("patientId"),
+                tenant=user_def.get("tenant", DEFAULT_PARTITION),
             )
             summary.results.append(result)
 
@@ -515,6 +525,12 @@ def main():
                         choices=["read-only", "read-write", "superuser"],
                         default="read-only",
                         help="Permission level (default: read-only)")
+    parser.add_argument("--tenant", default=DEFAULT_PARTITION,
+                        help="Partition name(s) the user may access, comma-separated "
+                             f"(default: {DEFAULT_PARTITION}). Vendor/scenario users "
+                             "should be scoped to their tenant only; partition access "
+                             "gates both reads and writes. In bulk mode set a per-user "
+                             "\"tenant\" key in the users file instead.")
     parser.add_argument("--practitioner-id",
                         help="Practitioner resource ID for EHR launch context (e.g., guthrie-aaron)")
     parser.add_argument("--patient-id",
@@ -615,6 +631,7 @@ def main():
             permission_level=args.permissions,
             practitioner_id=args.practitioner_id,
             patient_id=args.patient_id,
+            tenant=args.tenant,
         )
         duration = round(time.time() - start_time, 2)
 

--- a/scripts/register_smart_client.py
+++ b/scripts/register_smart_client.py
@@ -111,9 +111,9 @@ DEFAULT_BACKEND_SCOPES = ["system/*.read"]
 DEFAULT_PARTITION = "DEFAULT"
 
 
-def fhir_base_suffix(node: str = DEFAULT_NODE) -> str:
-    """Return the FHIR base URL path for a given node."""
-    return f"{node}/fhir/{DEFAULT_PARTITION}"
+def fhir_base_suffix(node: str = DEFAULT_NODE, tenant: str = DEFAULT_PARTITION) -> str:
+    """Return the FHIR base URL path for a given node and tenant."""
+    return f"{node}/fhir/{tenant}"
 
 
 # =============================================================================
@@ -152,7 +152,7 @@ class RegistrationSummary:
 # Permission Mapping
 # =============================================================================
 
-def scopes_to_authorities(scopes: List[str]) -> List[Dict]:
+def scopes_to_authorities(scopes: List[str], tenant: str = DEFAULT_PARTITION) -> List[Dict]:
     """Map SMART scopes to SmileCDR permissions for backend service clients.
 
     Backend Service clients need explicit permissions because there is no user
@@ -168,7 +168,7 @@ def scopes_to_authorities(scopes: List[str]) -> List[Dict]:
     authorities = [
         {"permission": "ROLE_FHIR_CLIENT"},
         {"permission": "FHIR_CAPABILITIES"},
-        {"permission": "FHIR_ACCESS_PARTITION_NAME", "argument": DEFAULT_PARTITION},
+        {"permission": "FHIR_ACCESS_PARTITION_NAME", "argument": tenant},
     ]
 
     has_read = False
@@ -244,6 +244,7 @@ def build_backend_service_payload(
     node_id: str = DEFAULT_NODE,
     client_secret: Optional[str] = None,
     access_token_timeout: int = 3600,
+    tenant: str = DEFAULT_PARTITION,
 ) -> Dict:
     """Build payload for a Backend Service (confidential) client.
 
@@ -272,7 +273,7 @@ def build_backend_service_payload(
         "canIntrospectAnyTokens": False,
         "canReissueTokens": False,
         "attestationAccepted": True,
-        "permissions": scopes_to_authorities(scopes),
+        "permissions": scopes_to_authorities(scopes, tenant=tenant),
         "_generated_secret": client_secret,
     }
 
@@ -313,9 +314,10 @@ class SmartClientRegistrar:
 
     def __init__(self, base_url: str, auth_header: str, node_id: str = DEFAULT_NODE,
                  dry_run: bool = False, skip_existing: bool = True,
-                 update_existing: bool = False):
+                 update_existing: bool = False, tenant: str = DEFAULT_PARTITION):
         self.base_url = base_url.rstrip("/")
         self.node_id = node_id
+        self.tenant = tenant
         self.admin_url = f"{self.base_url}/{admin_json_path(node_id)}"
         self.dry_run = dry_run
         self.skip_existing = skip_existing
@@ -443,11 +445,11 @@ class SmartClientRegistrar:
 
         # Compute authorities from scopes (only for backend service clients)
         if is_backend:
-            new_authorities = scopes_to_authorities(scopes)
+            new_authorities = scopes_to_authorities(scopes, tenant=self.tenant)
         else:
             # For SMART App Launch clients, just ensure partition access is set
             new_authorities = [
-                {"permission": "FHIR_ACCESS_PARTITION_NAME", "argument": DEFAULT_PARTITION},
+                {"permission": "FHIR_ACCESS_PARTITION_NAME", "argument": self.tenant},
             ]
 
         # Merge: keep existing permissions, add missing ones
@@ -538,12 +540,18 @@ class SmartClientRegistrar:
             )
 
     def register_single(self, client_type: str, client_id: str, client_name: str,
-                         redirect_uris: List[str], scopes: List[str]) -> RegistrationResult:
-        """Register a single client by type."""
+                         redirect_uris: List[str], scopes: List[str],
+                         tenant: Optional[str] = None) -> RegistrationResult:
+        """Register a single client by type.
+
+        tenant overrides the registrar-level tenant for this one client
+        (used by bulk files with a per-client "tenant" key).
+        """
+        effective_tenant = tenant or self.tenant
         if client_type == "smart-app-launch":
             payload = build_smart_app_launch_payload(client_id, client_name, redirect_uris, scopes, node_id=self.node_id)
         elif client_type == "backend-service":
-            payload = build_backend_service_payload(client_id, client_name, scopes, node_id=self.node_id)
+            payload = build_backend_service_payload(client_id, client_name, scopes, node_id=self.node_id, tenant=effective_tenant)
         else:
             return RegistrationResult(
                 client_id=client_id,
@@ -578,8 +586,9 @@ class SmartClientRegistrar:
             client_name = client_def.get("clientName", client_id)
             scopes = client_def.get("scopes", DEFAULT_SMART_APP_SCOPES)
             redirect_uris = client_def.get("redirectUris", [])
+            tenant = client_def.get("tenant")
 
-            result = self.register_single(client_type, client_id, client_name, redirect_uris, scopes)
+            result = self.register_single(client_type, client_id, client_name, redirect_uris, scopes, tenant=tenant)
             summary.results.append(result)
 
             if result.updated and result.success:
@@ -760,6 +769,12 @@ def main():
                         choices=SUPPORTED_NODES,
                         help=f"Target SmileCDR node (default: {DEFAULT_NODE}). "
                              "Registers client on this node's smart_auth module and shows matching endpoints.")
+    parser.add_argument("--tenant", default=DEFAULT_PARTITION,
+                        help=f"Partition name(s) the client may access, comma-separated "
+                             f"(default: {DEFAULT_PARTITION}). Vendor/scenario clients should "
+                             "be scoped to their tenant only; partition access gates both "
+                             "reads and writes. In bulk mode a per-client \"tenant\" key "
+                             "in the clients file overrides this.")
 
     # Bulk options
     parser.add_argument("--bulk", action="store_true",
@@ -797,6 +812,7 @@ def main():
         dry_run=args.dry_run,
         skip_existing=args.skip_existing,
         update_existing=args.update_existing,
+        tenant=args.tenant,
     )
 
     if args.bulk:


### PR DESCRIPTION
## Summary

Implementation PR for ADR 0001 (partition-based multitenancy). Ships the tooling changes and records the executed ereq pilot.

## Changes

- **manage_smart_users.py / register_smart_client.py**: new --tenant argument (plus per-entry "tenant" key in bulk files) so users and backend-service clients can be scoped to a vendor or scenario partition via FHIR_ACCESS_PARTITION_NAME instead of always DEFAULT
- **smart-post-authorize.js**: fhirUser and launch-context URLs are now derived from the request audience (with aud-parameter fallback) instead of a hardcoded aucore/DEFAULT base, so tokens minted for tenant endpoints carry tenant-correct URLs
- **Issue template 05**: optional Tenant field on SMART client registration requests
- **ADR 0001 / rollout plan**: Phase 2 scope adjusted per team decision: team accounts (ADMIN, DevTester, placer, filler) keep read/write on DEFAULT; read-only DEFAULT applies to participant principals
- **docs/multitenancy-demo.md**: verified six-command demo walkthrough of the ereq pilot
- **Rollout plan execution log**: Phases 0 to 2 executed on ereq 2026-07-13/14

## Verification

The pilot was executed live on ereq using this branch's tooling, with zero pod restarts:

- Tenants SCENARIO-EREQ-MEDS (100) and VENDOR-DEMO (101) created at runtime; anonymous requests to them return 403 while DEFAULT reads are unchanged
- demo-placer / demo-filler / demo-vendor created via the new --tenant flag; a validated medications flow (AMT-coded MedicationRequest plus fulfil Task) was loaded by demo-placer and driven requested -> in-progress -> completed by demo-filler entirely inside the scenario tenant
- Isolation verified: tenant-scoped users get 403 on both read and write against DEFAULT and against each other's tenants
- Participant write removal on ereq DEFAULT verified: only team accounts and tenant-scoped demo users retain write anywhere
- Python scripts py_compile clean; JS syntax-checked; every command in the demo doc executed against the live server