### PR TITLE
Smile CDR 2026.05 upgrade plan and verification tooling

### DIFF
--- a/docs/smilecdr-2026.05-upgrade-plan.md
+++ b/docs/smilecdr-2026.05-upgrade-plan.md
@@ -217,6 +217,19 @@ The full path (if the migrated schema itself misbehaves) is restoring the phase 
 Aurora snapshot and reverting the PR. Either way, take the decision before new
 clinical data accumulates on the upgraded schema.
 
+#### Phase 2 outcome (applied 2026-07-14)
+
+Completed cleanly (PR #70, helm revision 13). All three nodes rolled onto
+`2026.05.R01`; each logged `migrated successfully: ... 5 succeeded, 0 failed` for
+persistence at first boot, with no ERROR/FATAL lines (the WARN about
+`schema_update_mode: UPDATE` in production is expected and pre-existing). The
+post-phase smoke run was identical to the baseline modulo the version string: 30
+passed, 1 known hl7au failure, and both `$summary` checks passed, so the AUPS
+generator jars are compatible with the 2026.05 HAPI internals and no rebuild is
+needed. Outstanding manual check: one SMART authorization-code login (demo flow) to
+exercise `smart-post-authorize.js` fhirUser injection under the 2026.05 GraalVM
+sandbox; the script's audited API surface suggests no issue.
+
 ## Verification
 
 ### Automated: scripts/upgrade_smoke_tests.sh

--- a/docs/smilecdr-2026.05-upgrade-plan.md
+++ b/docs/smilecdr-2026.05-upgrade-plan.md
@@ -226,9 +226,34 @@ persistence at first boot, with no ERROR/FATAL lines (the WARN about
 post-phase smoke run was identical to the baseline modulo the version string: 30
 passed, 1 known hl7au failure, and both `$summary` checks passed, so the AUPS
 generator jars are compatible with the 2026.05 HAPI internals and no rebuild is
-needed. Outstanding manual check: one SMART authorization-code login (demo flow) to
-exercise `smart-post-authorize.js` fhirUser injection under the 2026.05 GraalVM
-sandbox; the script's audited API surface suggests no issue.
+needed.
+
+#### Post-upgrade functional checks (2026-07-14)
+
+All three remaining risk areas were exercised on the live 2026.05.R01 deployment:
+
+- SMART authorization-code flow (ereq): full login as DevTester via
+  `ereq/smartauth` using the public `ereq-connectathon` client (signin, CSRF form,
+  consent approval, code issuance, token exchange). The token endpoint returned 200
+  with `fhirUser` populated in the id_token (RelatedPerson fallback, expected for a
+  user with no practitioner launch context), the pod log shows the script executor
+  loading `smart-post-authorize.js` without error, and the issued bearer token
+  performed a live FHIR read. The 2026.05 GraalVM sandbox risk is closed.
+- Package registry round-trip (ereq): `hl7.fhir.au.ereq@1.0.0` was uninstalled and
+  reinstalled via `scripts/sync_packages.py --force-reinstall` (DELETE then PUT on
+  the package write API). Package search, reindexing, and the DEFAULT-partition
+  StructureDefinition count (142) all returned to their pre-operation state.
+- Test data delete/reload (ereq DEFAULT, targeted): the 50 au-erequesting resources
+  from `hl7au/au-fhir-test-data` were deleted and reloaded with the
+  sparked-test-data-loader (run locally). All resource counts returned exactly to
+  pre-operation values. Note: each 50-request bulk run had exactly one transient
+  HTTP 401 (a delete in one run, a create in the other), both succeeded on retry;
+  worth watching whether 2026.05 introduced an intermittent basic-auth hiccup under
+  burst load.
+- CI gap found: the Manage Test Data / Clear Test Data workflows fail on
+  `arc-runner-set` before doing any work; the runner cannot pull
+  `sparked-test-data-loader` from ECR ("no basic auth credentials"). Runner-side ECR
+  credential regression, tracked as a follow-up.
 
 ## Verification
 
@@ -285,4 +310,9 @@ multitenancy tests). Checks per node (aucore, hl7au, ereq) and per ereq tenant
 - Move module and chart to 9.1+/9.2+ once upstream fixes the
   `_copy_files_node_overlay` plan error for multi-node deployments.
 - hl7au smartauth context path returns 404 (SMART outbound module not live on that
-  node); pre-existing, investigate separately.
+  node); pre-existing, expected (hl7au is not fully set up).
+- Fix ECR image pull on `arc-runner-set` so the Manage/Clear/Load Test Data
+  workflows work again (currently "no basic auth credentials" pulling
+  sparked-test-data-loader).
+- Watch for intermittent single HTTP 401s during bulk FHIR operations on 2026.05
+  (one per 50-request burst observed twice on 2026-07-14; retries succeeded).

--- a/docs/smilecdr-2026.05-upgrade-plan.md
+++ b/docs/smilecdr-2026.05-upgrade-plan.md
@@ -167,6 +167,28 @@ confirm the new Ingress `smilecdr-scdr-default` serves all paths.
 
 Rollback: revert the PR and re-apply. No data or schema involvement.
 
+#### Phase 1 outcome (applied 2026-07-14)
+
+Completed, with one gotcha the render diff could not predict: helm creates the renamed
+Ingress before deleting the old one, and the ingress-nginx validating admission
+webhook rejects the new Ingress because the old one still defines the same host+paths.
+The first apply therefore failed at the Ingress step (PR #68, helm revision 11
+`failed`). The partial upgrade was safe: ConfigMaps and Deployments had already
+updated (pods rolled onto the new spec, image still 2025.11.R02, new `filecopy.sh`
+init containers worked), and the old Ingress kept serving throughout.
+
+Resolution: manually swapped the Ingress (delete `smilecdr-scdr`, immediately apply
+the rendered `smilecdr-scdr-default` carrying `meta.helm.sh/release-name` /
+`meta.helm.sh/release-namespace` annotations and the `app.kubernetes.io/managed-by:
+Helm` label so helm adopts it), observed a routing gap of a few seconds, then
+re-dispatched APPLY. Helm adopted the Ingress and reconciled to `deployed` (revision
+12). Post-phase smoke run: identical to baseline (30 passed, 1 known hl7au failure).
+
+Lesson for future ingress renames behind ingress-nginx: the webhook makes
+create-before-delete renames impossible in one apply; plan the manual swap (or a
+temporary second hostname) up front. Phase 2 renames nothing, so no recurrence is
+expected.
+
 ### Phase 2: Smile CDR 2025.11.R02 to 2026.05.R01
 
 One PR changing `module-config/values-common.yaml` only:

--- a/docs/smilecdr-2026.05-upgrade-plan.md
+++ b/docs/smilecdr-2026.05-upgrade-plan.md
@@ -1,0 +1,221 @@
+# Smile CDR 2026.05 upgrade plan
+
+Upgrade the Sparked FHIR server from Smile CDR `2025.11.R02` (Helm chart `7.1.0`) to
+`2026.05.R01` (Helm chart `9.2.0`), with a verifiable, two-phase rollout and rollback
+paths at each step.
+
+Reference docs:
+
+- Chart upgrade guide: <https://smilecdr-public.gitlab.io/smile-dh-helm-charts/v9.0/upgrading/>
+- Chart migration guides: <https://smilecdr-public.gitlab.io/smile-dh-helm-charts/v9.0/upgrading/migration-guides/>
+- Smile CDR upgrade guide: <https://smilecdr.com/docs/installation/upgrading.html>
+- Smile CDR changelog: <https://smilecdr.com/docs/welcome/changelog.html>
+
+## Current vs target state
+
+| Component | Current | Target |
+|---|---|---|
+| Smile CDR | 2025.11.R02 (`cdrVersion` in `module-config/values-common.yaml`) | 2026.05.R01 |
+| Helm chart | smilecdr 7.1.0 (`helm_chart_version` in `terraform/main.tf`) | smilecdr 9.2.0 |
+| Terraform module | `sdh-deps` at `ref=v9.0.2` | `ref=v9.2.0` |
+| Message broker | Embedded ActiveMQ (chart default, no Kafka) | unchanged |
+| Ingress | nginx-ingress, explicitly pinned via `ingress_config` | unchanged |
+| Database | Aurora Postgres Serverless v2, engine 14.20 | unchanged |
+
+## Investigation findings
+
+### Version compatibility
+
+- Chart v9 supports Smile CDR `2025.05.R01` through `2026.05.R01`. Chart `9.2.0`
+  defaults to (`appVersion`) `2026.05.R01`. This means the chart can be upgraded first
+  while `cdrVersion` stays pinned at `2025.11.R02`, isolating the chart hop from the
+  application hop.
+- Smile CDR upgrade policy: "Smile CDR can only be upgraded by two quarterly generally
+  available releases at a time, e.g. 2023.11 to 2024.05" (online mode). Our jump
+  2025.11 to 2026.05 is exactly two GA releases, so it is within the supported window
+  and no intermediate stop at 2026.02 is required. Offline upgrades have no window
+  limit at all, and with `replicaCount: 1` per node every rollout is effectively a
+  brief offline upgrade anyway.
+- PostgreSQL: 2026.05 supports v12 and above (v16 recommended). Aurora 14.20 remains
+  supported. A later Aurora 14 to 16 upgrade is worth considering but is out of scope
+  here.
+- Chart 9.1.x and 9.2.0 minor releases only add features (mostly Azure/AKS and DNS
+  passthrough); nothing that affects this deployment.
+
+### Chart migration guides: what applies to us
+
+- v7 to v8 breaking change: default ingress type on EKS changed from `nginx-ingress`
+  to `aws-lbc-gwapi` (Gateway API). Does not bite: `terraform/main.tf` explicitly sets
+  `ingressType = "nginx-ingress"` with `useDefaultIngress = true`. Note the guide
+  marks nginx-ingress retention as deprecated, so a Gateway API migration should be
+  planned eventually (separate piece of work).
+- v8 to v9 breaking change: Strimzi-managed Kafka moved to KRaft/KafkaNodePool and
+  requires Strimzi operator 1.0.0 or later, with deprecated `messageBroker.strimzi.*`
+  values shapes now failing the render. Does not apply: this deployment uses the
+  embedded ActiveMQ broker (chart default, confirmed in the rendered
+  `Master.properties`) and runs no Strimzi operator.
+- `ingresses.default.useLegacyResourceSuffix` (default `true` in v7) is deprecated and
+  disabled in v9. We never set it, so the only effect is the Ingress resource rename
+  described below.
+
+### Render diff evidence (chart 7.1.0 vs 9.2.0, live values)
+
+Both chart versions were rendered offline with `helm template` using the exact values
+of the live release (`helm get values smilecdr -n smile`), for both
+`cdrVersion: 2025.11.R02` and `2026.05.R01`. All four renders succeed (no deprecated
+values failures). Diffing the 7.1.0 and 9.2.0 manifests:
+
+- The only resource added, removed, or renamed across the whole release:
+  `Ingress smilecdr-scdr` becomes `Ingress smilecdr-scdr-default`. The spec is
+  byte-identical (same class, host, annotations, and 18 paths; no TLS block, TLS
+  terminates upstream of the nginx controller). Helm deletes the old Ingress and
+  creates the new one in the same apply; the nginx controller reconciles in seconds.
+- Deployments gain `SMILECDR_BASE_URL`, `SMILECDR_NODE_ID`, `JS_SMILECDR_BASE_URL`,
+  `JS_SMILECDR_NODE_ID` env vars, and the S3 `copyFiles` init container is reworked
+  from a raw `aws s3 cp` args list to a mounted `filecopy.sh` script (aws-cli image
+  2.13 to 2.33). Same jars end up in `customerlib`.
+- The rendered `cdr-config-Master.properties` is functionally identical per node (one
+  property reordered, whitespace normalisation only).
+- The ConfigMap content hash changes, so all three node Deployments roll once per
+  phase. With one replica per node that is a short outage per node, as with any config
+  change today.
+
+### Smile CDR application changes 2025.11 to 2026.05
+
+- 2026.02: a "case-sensitive FHIR ID" database migration lands. It is flagged as
+  breaking zero-downtime only for a subset of SQL Server users; on Postgres it is a
+  regular (potentially long-running on large data) migration. All three nodes run
+  `db.schema_update_mode = UPDATE` for both clustermgr and persistence, so migrations
+  execute at first boot on the new version. Our datasets are small, so expect minutes,
+  not hours. Also in 2026.02: Mongo persistence deprecated (not used), Java API class
+  renames (only relevant to custom Java, see AUPS risk below).
+- 2026.05: GraalVM JavaScript environments are locked down. Scripts may no longer
+  instantiate arbitrary Java types (allow-listing required) or read arbitrary files
+  from disk. `module-config/smart-post-authorize.js` was audited against this: it only
+  uses the injected API objects (`theUserSession`, `theAuthorizationRequestDetails`,
+  `Log`, `Converter`, `JSON`), no `Java.type()` and no file access, so it should be
+  unaffected. SMART flows are still an explicit verification item.
+- 2026.05: Camel 4.10 to 4.18 (kebab-case route names dropped), MDM/MongoDB breakage,
+  JWK validation priority changes. None used by this deployment.
+
+### Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| AUPS generator jars break against 2026.05 HAPI internals | Medium | `$summary` (AU Patient Summary) fails on aucore/ereq | The jars (`hapi-aups-generator` 1.0.1 on aucore, 0.1.0-alpha on ereq, 1.0.0 on hl7au) extend `ca.uhn.fhir.jpa.ips.jpa.DefaultJpaIpsGenerationStrategy` and other HAPI JPA IPS internals that move between HAPI releases. Smoke test runs `$summary` on both nodes immediately after phase 2; if it fails, rebuild the jars in `aehrc/sparked-fhir-operations` against the 2026.05 HAPI version and bump the S3 artifacts. FHIR CRUD is unaffected either way |
+| `smart-post-authorize.js` hits the new GraalVM sandbox | Low | SMART EHR/standalone launch token issuance fails | Script audited clean (no Java instantiation, no file reads). Verify an authorization-code login and a client_credentials token after phase 2 |
+| Case-sensitive FHIR ID migration runs long or fails at boot | Low | Node stays unready after phase 2 | Small DB; watch pod logs for migration progress on first 2026.05 boot. Aurora snapshot taken beforehand is the recovery path |
+| Ingress rename causes a routing gap | Low | Seconds of 404s at most | Old and new Ingress swap within one helm apply; the nginx controller reconciles quickly. Verify all context paths right after phase 1 |
+| 2026.05.R01 image not pullable with our registry credentials | Low | Pods stuck in ImagePullBackOff, old pods keep serving until then | Rollout is RollingUpdate; a pull failure leaves the old ReplicaSet serving. Revert the PR if entitlement is missing |
+
+## Upgrade plan
+
+Both phases ship as ordinary PRs through the existing pipeline: the `Smile
+Configuration Deployment` workflow posts the terraform plan on the PR, and apply is a
+manually confirmed `workflow_dispatch` (type `APPLY`) after merge.
+
+### Phase 0: preparation (no changes)
+
+1. Pick a quiet window and give connectathon participants notice; each phase rolls all
+   three nodes (about 2 to 5 minutes of downtime per node, sequential).
+2. Take a manual Aurora cluster snapshot of `SmileCluster` (console or
+   `aws rds create-db-cluster-snapshot`). This is the phase 2 rollback anchor.
+3. Capture a baseline: `./scripts/upgrade_smoke_tests.sh -o baseline.md` and keep the
+   output. It records per-node/per-tenant software versions, resource counts, and
+   endpoint health to compare after each phase.
+
+### Phase 1: chart 7.1.0 to 9.2.0, Smile CDR unchanged
+
+One PR changing `terraform/main.tf` only:
+
+```hcl
+source             = "git::https://gitlab.com/smilecdr-public/smile-dh-helm-charts//src/main/terraform/sdh-deps?ref=v9.2.0"
+helm_chart_version = "9.2.0"
+```
+
+`cdrVersion` stays `2025.11.R02` in `values-common.yaml`, so this phase changes
+Kubernetes packaging only, with the application config proven identical by the render
+diff. The module bump v9.0.2 to v9.2.0 is additive for our inputs (the one changed
+variable, `extra_secrets`, is deliberately unused here).
+
+Expected plan/apply surface: Ingress rename, Deployment env/init-container changes,
+ConfigMap hash roll. Expected NOT to appear: any change to RDS, IAM, Route53, or the
+CDR properties.
+
+After apply: run the smoke tests, expect all green with version still 2025.11.R02, and
+confirm the new Ingress `smilecdr-scdr-default` serves all paths.
+
+Rollback: revert the PR and re-apply. No data or schema involvement.
+
+### Phase 2: Smile CDR 2025.11.R02 to 2026.05.R01
+
+One PR changing `module-config/values-common.yaml` only:
+
+```yaml
+cdrVersion: "2026.05.R01"
+```
+
+On apply, pods roll onto the `docker.smilecdr.com/smilecdr:2026.05.R01` image and each
+node runs its schema migrations at boot (`schema_update_mode: UPDATE`), including the
+2026.02 case-sensitive FHIR ID migration and the 2026.05 set.
+
+During apply, watch first boot on each node:
+
+```bash
+kubectl logs -n smile -l app.kubernetes.io/name=smilecdr -f | grep -iE "migrat|flyway|schema|ERROR"
+```
+
+After apply: run the full smoke suite with the version assertion,
+`./scripts/upgrade_smoke_tests.sh --expect-version 2026.05.R01 -o phase2.md`, then the
+manual checks below.
+
+Rollback: Smile CDR processes are designed to run against a schema up to two versions
+ahead, so the fast path is reverting `cdrVersion` to `2025.11.R02` and re-applying.
+The full path (if the migrated schema itself misbehaves) is restoring the phase 0
+Aurora snapshot and reverting the PR. Either way, take the decision before new
+clinical data accumulates on the upgraded schema.
+
+## Verification
+
+### Automated: scripts/upgrade_smoke_tests.sh
+
+Run before phase 1 (baseline), after phase 1, and after phase 2. Read-only by default;
+admin credentials come from AWS Secrets Manager at runtime (same pattern as the phase 0
+multitenancy tests). Checks per node (aucore, hl7au, ereq) and per ereq tenant
+(DEFAULT, SCENARIO-EREQ-MEDS, VENDOR-DEMO):
+
+- `metadata` returns 200 and reports the expected Smile CDR version
+  (`--expect-version` makes a mismatch a failure).
+- SMART discovery: `.well-known/smart-configuration` on the FHIR endpoint and the
+  OIDC `openid-configuration` on the smartauth endpoint.
+- Data integrity: Patient and StructureDefinition counts per node/tenant, compared
+  against the baseline run by eye (counts are printed side by side in the results
+  file).
+- IG seeding: the AU Core patient profile StructureDefinition resolves on aucore.
+- Request validation still rejects an invalid resource (`$validate`).
+- Ingress body-size limit: a padded ~3 MiB `$validate` request must not return
+  HTTP 413.
+- AUPS generation: `Patient/{id}/$summary` on aucore DEFAULT and ereq
+  SCENARIO-EREQ-MEDS returns a document Bundle (the custom generator risk).
+- `--write` additionally does a create/read/delete round-trip with a tagged test
+  Patient (off by default).
+
+### Manual checks after phase 2
+
+1. SMART authorization-code login with a demo user against
+   `ereq/smartauth` (the multitenancy demo flow), confirming the issued token carries
+   the Practitioner `fhirUser` claim, which exercises `smart-post-authorize.js` under
+   the new GraalVM sandbox.
+2. Admin console loads at `/aucore/console` and modules show green.
+3. OpenTelemetry: traces/metrics still arriving in the monitoring stack (the agent is
+   injected by the operator, independent of the CDR version, but the
+   instrumented Kafka/HL7v2 method names in `OTEL_INSTRUMENTATION_METHODS_INCLUDE`
+   should be spot-checked for renames if traces go quiet).
+4. Skim `kubectl logs` on each node for new WARN/ERROR patterns.
+
+## Out of scope / follow-ups
+
+- Gateway API migration off nginx-ingress (v8 guide marks nginx retention as
+  deprecated). Plan separately.
+- Aurora Postgres 14 to 16 upgrade (16 is the recommended version for 2026.05).
+- Rebuild of the AUPS generator jars against 2026.05 HAPI: only if `$summary` breaks.

--- a/docs/smilecdr-2026.05-upgrade-plan.md
+++ b/docs/smilecdr-2026.05-upgrade-plan.md
@@ -1,8 +1,19 @@
 # Smile CDR 2026.05 upgrade plan
 
 Upgrade the Sparked FHIR server from Smile CDR `2025.11.R02` (Helm chart `7.1.0`) to
-`2026.05.R01` (Helm chart `9.2.0`), with a verifiable, two-phase rollout and rollback
+`2026.05.R01` (Helm chart `9.0.2`), with a verifiable, two-phase rollout and rollback
 paths at each step.
+
+Three version levers are involved, and they are deliberately decoupled:
+
+1. Terraform module ref (`?ref=` in `terraform/main.tf`): the `sdh-deps` module code
+   that creates AWS resources and drives the helm release. Already at `v9.0.2` and
+   staying there (see below).
+2. `helm_chart_version` (`terraform/main.tf`): the smilecdr chart the module installs.
+   This is what the upgrade bumps to `9.0.2`.
+3. `cdrVersion` (`module-config/values-common.yaml`): the Smile CDR application/image
+   version. Pinned so a chart bump cannot silently change the running release; bumped
+   separately to `2026.05.R01`.
 
 Reference docs:
 
@@ -16,8 +27,8 @@ Reference docs:
 | Component | Current | Target |
 |---|---|---|
 | Smile CDR | 2025.11.R02 (`cdrVersion` in `module-config/values-common.yaml`) | 2026.05.R01 |
-| Helm chart | smilecdr 7.1.0 (`helm_chart_version` in `terraform/main.tf`) | smilecdr 9.2.0 |
-| Terraform module | `sdh-deps` at `ref=v9.0.2` | `ref=v9.2.0` |
+| Helm chart | smilecdr 7.1.0 (`helm_chart_version` in `terraform/main.tf`) | smilecdr 9.0.2 |
+| Terraform module | `sdh-deps` at `ref=v9.0.2` | unchanged (v9.1.x/v9.2.0 are broken for us, see below) |
 | Message broker | Embedded ActiveMQ (chart default, no Kafka) | unchanged |
 | Ingress | nginx-ingress, explicitly pinned via `ingress_config` | unchanged |
 | Database | Aurora Postgres Serverless v2, engine 14.20 | unchanged |
@@ -26,10 +37,19 @@ Reference docs:
 
 ### Version compatibility
 
-- Chart v9 supports Smile CDR `2025.05.R01` through `2026.05.R01`. Chart `9.2.0`
+- Chart v9 supports Smile CDR `2025.05.R01` through `2026.05.R01`. Chart `9.0.2`
   defaults to (`appVersion`) `2026.05.R01`. This means the chart can be upgraded first
   while `cdrVersion` stays pinned at `2025.11.R02`, isolating the chart hop from the
   application hop.
+- Chart target is `9.0.2`, not the newest `9.2.0`: the terraform module was pinned to
+  `v9.0.2` (commit `348bbf5`) because module `v9.1.x`/`v9.2.0` carry an upstream
+  `_copy_files_node_overlay` type error that breaks `terraform plan` for any
+  multi-node deployment, which this is. The bug is still present at `v9.2.0` (checked
+  2026-07-14; no newer tag exists). Keeping the module and chart on the same tag is
+  the combination upstream actually tests. Chart-side, `9.0.2` vs `9.2.0` was render
+  diffed with the live values: the only difference is additive
+  `SMILECDR_BASE_URL`/`SMILECDR_NODE_ID` env vars in `9.1+`, so nothing of value is
+  lost by staying on `9.0.2`.
 - Smile CDR upgrade policy: "Smile CDR can only be upgraded by two quarterly generally
   available releases at a time, e.g. 2023.11 to 2024.05" (online mode). Our jump
   2025.11 to 2026.05 is exactly two GA releases, so it is within the supported window
@@ -39,8 +59,9 @@ Reference docs:
 - PostgreSQL: 2026.05 supports v12 and above (v16 recommended). Aurora 14.20 remains
   supported. A later Aurora 14 to 16 upgrade is worth considering but is out of scope
   here.
-- Chart 9.1.x and 9.2.0 minor releases only add features (mostly Azure/AKS and DNS
-  passthrough); nothing that affects this deployment.
+- Chart 9.1.x and 9.2.0 minor releases only add features chart-side (mostly Azure/AKS
+  and DNS passthrough), but their terraform module releases are unusable here per the
+  `_copy_files_node_overlay` bug above. Revisit once upstream ships a fixed tag.
 
 ### Chart migration guides: what applies to us
 
@@ -58,12 +79,13 @@ Reference docs:
   disabled in v9. We never set it, so the only effect is the Ingress resource rename
   described below.
 
-### Render diff evidence (chart 7.1.0 vs 9.2.0, live values)
+### Render diff evidence (chart 7.1.0 vs 9.0.2, live values)
 
 Both chart versions were rendered offline with `helm template` using the exact values
 of the live release (`helm get values smilecdr -n smile`), for both
-`cdrVersion: 2025.11.R02` and `2026.05.R01`. All four renders succeed (no deprecated
-values failures). Diffing the 7.1.0 and 9.2.0 manifests:
+`cdrVersion: 2025.11.R02` and `2026.05.R01` (chart 9.2.0 was also rendered and
+matches 9.0.2 apart from the additive env vars noted above). All renders succeed (no
+deprecated values failures). Diffing the 7.1.0 and 9.0.2 manifests:
 
 - The only resource added, removed, or renamed across the whole release:
   `Ingress smilecdr-scdr` becomes `Ingress smilecdr-scdr-default`. The spec is
@@ -124,19 +146,17 @@ manually confirmed `workflow_dispatch` (type `APPLY`) after merge.
    output. It records per-node/per-tenant software versions, resource counts, and
    endpoint health to compare after each phase.
 
-### Phase 1: chart 7.1.0 to 9.2.0, Smile CDR unchanged
+### Phase 1: chart 7.1.0 to 9.0.2, Smile CDR unchanged
 
-One PR changing `terraform/main.tf` only:
+One PR changing a single line in `terraform/main.tf` (the module ref stays `v9.0.2`):
 
 ```hcl
-source             = "git::https://gitlab.com/smilecdr-public/smile-dh-helm-charts//src/main/terraform/sdh-deps?ref=v9.2.0"
-helm_chart_version = "9.2.0"
+helm_chart_version = "9.0.2"
 ```
 
 `cdrVersion` stays `2025.11.R02` in `values-common.yaml`, so this phase changes
 Kubernetes packaging only, with the application config proven identical by the render
-diff. The module bump v9.0.2 to v9.2.0 is additive for our inputs (the one changed
-variable, `extra_secrets`, is deliberately unused here).
+diff.
 
 Expected plan/apply surface: Ingress rename, Deployment env/init-container changes,
 ConfigMap hash roll. Expected NOT to appear: any change to RDS, IAM, Route53, or the
@@ -179,6 +199,14 @@ clinical data accumulates on the upgraded schema.
 
 ### Automated: scripts/upgrade_smoke_tests.sh
 
+Baseline run 2026-07-14 against 2025.11.R02: 30 passed, 1 failed. The single failure
+is pre-existing and unrelated to the upgrade: `hl7au` returns 404 for its whole
+`smartauth` context path (OIDC discovery included), i.e. the SMART outbound security
+module is not actually live on that node despite being configured in
+`simplified-multinode.yaml`. Expect the same single failure after each phase; treat
+any NEW failure as an upgrade regression. The hl7au smartauth gap is tracked as a
+follow-up.
+
 Run before phase 1 (baseline), after phase 1, and after phase 2. Read-only by default;
 admin credentials come from AWS Secrets Manager at runtime (same pattern as the phase 0
 multitenancy tests). Checks per node (aucore, hl7au, ereq) and per ereq tenant
@@ -219,3 +247,7 @@ multitenancy tests). Checks per node (aucore, hl7au, ereq) and per ereq tenant
   deprecated). Plan separately.
 - Aurora Postgres 14 to 16 upgrade (16 is the recommended version for 2026.05).
 - Rebuild of the AUPS generator jars against 2026.05 HAPI: only if `$summary` breaks.
+- Move module and chart to 9.1+/9.2+ once upstream fixes the
+  `_copy_files_node_overlay` plan error for multi-node deployments.
+- hl7au smartauth context path returns 404 (SMART outbound module not live on that
+  node); pre-existing, investigate separately.

--- a/scripts/upgrade_smoke_tests.sh
+++ b/scripts/upgrade_smoke_tests.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Smoke tests for Smile CDR upgrades (see docs/smilecdr-2026.05-upgrade-plan.md).
+#
+# Read-only by default. Run once before an upgrade to capture a baseline, then
+# after each upgrade phase and compare the results files.
+#
+# Usage:
+#   ./upgrade_smoke_tests.sh [-o results.md] [--expect-version 2026.05.R01] [--write]
+#
+#   -o FILE             write markdown results to FILE (default: upgrade-smoke-results.md)
+#   --expect-version V  fail if any node does not report Smile CDR version V
+#   --write             also do a create/read/delete round-trip with a tagged test
+#                       Patient on ereq DEFAULT (off by default)
+#
+# Requires: curl, jq, aws CLI with access to the smilecdr-user-passwords secret.
+set -u
+
+BASE="https://smile.sparked-fhir.com"
+NODES=(aucore hl7au ereq)
+EREQ_TENANTS=(DEFAULT SCENARIO-EREQ-MEDS VENDOR-DEMO)
+RESULTS="upgrade-smoke-results.md"
+EXPECT_VERSION=""
+DO_WRITE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) RESULTS="$2"; shift 2 ;;
+    --expect-version) EXPECT_VERSION="$2"; shift 2 ;;
+    --write) DO_WRITE=1; shift ;;
+    *) echo "Unknown argument: $1"; exit 2 ;;
+  esac
+done
+
+ADMIN_PASS=$(aws secretsmanager get-secret-value --secret-id smilecdr-user-passwords \
+  --query SecretString --output text | jq -r '."smilecdr-admin-password"')
+if [ -z "$ADMIN_PASS" ] || [ "$ADMIN_PASS" = "null" ]; then
+  echo "FATAL: could not fetch admin password from Secrets Manager"; exit 1
+fi
+
+PASS=0; FAIL=0; SKIP=0
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+echo "# Upgrade smoke test results ($(date -u '+%Y-%m-%d %H:%M UTC'))" > "$RESULTS"
+[ -n "$EXPECT_VERSION" ] && echo "Expected Smile CDR version: $EXPECT_VERSION" >> "$RESULTS"
+
+note()  { echo "$1" | tee -a "$RESULTS"; }
+ok()    { PASS=$((PASS+1)); note "- PASS: $1"; }
+bad()   { FAIL=$((FAIL+1)); note "- FAIL: $1"; }
+skip()  { SKIP=$((SKIP+1)); note "- SKIP: $1"; }
+
+# curl helpers: capture status code, body goes to a temp file, never echo credentials
+acurl() { curl -s --max-time 60 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/fhir+json" "$@"; }
+anoncurl() { curl -s --max-time 60 -H "Content-Type: application/fhir+json" "$@"; }
+
+# ---------------------------------------------------------------------------
+# Per-node checks
+# ---------------------------------------------------------------------------
+for node in "${NODES[@]}"; do
+  note ""
+  note "## Node: $node"
+  fhir="$BASE/$node/fhir/DEFAULT"
+
+  # 1. metadata + version
+  code=$(anoncurl -o "$TMP/meta.json" -w "%{http_code}" "$fhir/metadata")
+  if [ "$code" = "200" ]; then
+    ver=$(jq -r '.software.version // empty' "$TMP/meta.json")
+    ok "metadata HTTP 200 (software.version: ${ver:-unknown})"
+    if [ -n "$EXPECT_VERSION" ]; then
+      case "$ver" in
+        *"$EXPECT_VERSION"*) ok "version matches expected $EXPECT_VERSION" ;;
+        *) bad "version is '$ver', expected $EXPECT_VERSION" ;;
+      esac
+    fi
+  else
+    bad "metadata HTTP $code"
+  fi
+
+  # 2. SMART / OIDC discovery
+  code=$(anoncurl -o "$TMP/smart.json" -w "%{http_code}" "$fhir/.well-known/smart-configuration")
+  [ "$code" = "200" ] && ok "smart-configuration HTTP 200" || bad "smart-configuration HTTP $code"
+  code=$(anoncurl -o "$TMP/oidc.json" -w "%{http_code}" "$BASE/$node/smartauth/.well-known/openid-configuration")
+  [ "$code" = "200" ] && ok "openid-configuration HTTP 200" || bad "openid-configuration HTTP $code"
+
+  # 3. resource counts (compare across runs by eye)
+  for rt in Patient StructureDefinition; do
+    code=$(acurl -o "$TMP/count.json" -w "%{http_code}" "$fhir/$rt?_summary=count")
+    if [ "$code" = "200" ]; then
+      total=$(jq -r '.total // "?"' "$TMP/count.json")
+      ok "$rt count on DEFAULT: $total"
+    else
+      bad "$rt count on DEFAULT: HTTP $code"
+    fi
+  done
+
+  # 4. request validation still active: an invalid resource must not validate cleanly
+  code=$(acurl -o "$TMP/val.json" -w "%{http_code}" -X POST "$fhir/Patient/\$validate" \
+    -d '{"resourceType":"Patient","gender":"not-a-valid-gender"}')
+  issues=$(jq -r '[.issue[]? | select(.severity=="error" or .severity=="fatal")] | length' "$TMP/val.json" 2>/dev/null)
+  if [ "$code" = "422" ] || { [ "$code" = "200" ] && [ "${issues:-0}" -gt 0 ]; } || [ "$code" = "400" ]; then
+    ok "\$validate rejects invalid resource (HTTP $code, ${issues:-?} error issues)"
+  else
+    bad "\$validate unexpected result (HTTP $code, ${issues:-?} error issues)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# ereq tenant checks (multitenancy)
+# ---------------------------------------------------------------------------
+note ""
+note "## ereq tenants"
+for tenant in "${EREQ_TENANTS[@]}"; do
+  fhir="$BASE/ereq/fhir/$tenant"
+  code=$(anoncurl -o "$TMP/meta.json" -w "%{http_code}" "$fhir/metadata")
+  [ "$code" = "200" ] && ok "$tenant metadata HTTP 200" || bad "$tenant metadata HTTP $code"
+  code=$(acurl -o "$TMP/count.json" -w "%{http_code}" "$fhir/Patient?_summary=count")
+  if [ "$code" = "200" ]; then
+    ok "$tenant Patient count: $(jq -r '.total // "?"' "$TMP/count.json")"
+  else
+    bad "$tenant Patient count: HTTP $code"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# IG seeding: AU Core patient profile resolvable on aucore
+# ---------------------------------------------------------------------------
+note ""
+note "## IG package seeding"
+code=$(acurl -o "$TMP/sd.json" -w "%{http_code}" \
+  "$BASE/aucore/fhir/DEFAULT/StructureDefinition?url=http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient&_summary=count")
+if [ "$code" = "200" ] && [ "$(jq -r '.total // 0' "$TMP/sd.json")" -ge 1 ]; then
+  ok "au-core-patient StructureDefinition present on aucore"
+else
+  bad "au-core-patient StructureDefinition lookup (HTTP $code, total $(jq -r '.total // "?"' "$TMP/sd.json" 2>/dev/null))"
+fi
+
+# ---------------------------------------------------------------------------
+# Ingress body-size limit: ~3 MiB request must pass nginx (anything but 413)
+# ---------------------------------------------------------------------------
+note ""
+note "## Ingress body-size limit"
+python3 -c "
+import json
+pad = 'x' * (3 * 1024 * 1024)
+print(json.dumps({'resourceType':'Patient','text':{'status':'generated','div':'<div xmlns=\"http://www.w3.org/1999/xhtml\">'+pad+'</div>'}}))
+" > "$TMP/big.json" 2>/dev/null
+if [ -s "$TMP/big.json" ]; then
+  code=$(acurl -o "$TMP/bigresp.json" -w "%{http_code}" -X POST \
+    "$BASE/aucore/fhir/DEFAULT/Patient/\$validate" --data-binary "@$TMP/big.json")
+  if [ "$code" = "413" ]; then
+    bad "3 MiB request rejected with HTTP 413 (proxy-body-size regression)"
+  else
+    ok "3 MiB request passed the ingress (HTTP $code)"
+  fi
+else
+  skip "could not build large payload (python3 unavailable?)"
+fi
+
+# ---------------------------------------------------------------------------
+# AUPS generation ($summary via the custom generator jar)
+# ---------------------------------------------------------------------------
+note ""
+note "## AU Patient Summary (\$summary, custom AUPS generator)"
+for target in "aucore DEFAULT" "ereq SCENARIO-EREQ-MEDS"; do
+  set -- $target; node=$1; tenant=$2
+  fhir="$BASE/$node/fhir/$tenant"
+  code=$(acurl -o "$TMP/p.json" -w "%{http_code}" "$fhir/Patient?_count=1")
+  pid=$(jq -r '.entry[0].resource.id // empty' "$TMP/p.json" 2>/dev/null)
+  if [ "$code" != "200" ] || [ -z "$pid" ]; then
+    skip "$node/$tenant: no patient available to test \$summary (HTTP $code)"
+    continue
+  fi
+  code=$(acurl -o "$TMP/sum.json" -w "%{http_code}" "$fhir/Patient/$pid/\$summary")
+  btype=$(jq -r '.type // empty' "$TMP/sum.json" 2>/dev/null)
+  if [ "$code" = "200" ] && [ "$btype" = "document" ]; then
+    ok "$node/$tenant: \$summary returned a document Bundle for Patient/$pid"
+  else
+    bad "$node/$tenant: \$summary failed (HTTP $code, bundle type '${btype:-none}') for Patient/$pid"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Optional write path: create/read/delete a tagged test Patient (ereq DEFAULT)
+# ---------------------------------------------------------------------------
+if [ "$DO_WRITE" = "1" ]; then
+  note ""
+  note "## Write round-trip (ereq DEFAULT)"
+  fhir="$BASE/ereq/fhir/DEFAULT"
+  code=$(acurl -o "$TMP/create.json" -w "%{http_code}" -X POST "$fhir/Patient" -d '{
+    "resourceType":"Patient",
+    "identifier":[{"system":"urn:sparked:upgrade-smoke","value":"upgrade-smoke-test"}],
+    "name":[{"family":"UpgradeSmokeTest"}],
+    "gender":"other"
+  }')
+  pid=$(jq -r '.id // empty' "$TMP/create.json" 2>/dev/null)
+  if [ "$code" = "201" ] && [ -n "$pid" ]; then
+    ok "create Patient/$pid (HTTP 201)"
+    code=$(acurl -o /dev/null -w "%{http_code}" "$fhir/Patient/$pid")
+    [ "$code" = "200" ] && ok "read back Patient/$pid" || bad "read back Patient/$pid: HTTP $code"
+    code=$(acurl -o /dev/null -w "%{http_code}" -X DELETE "$fhir/Patient/$pid")
+    { [ "$code" = "200" ] || [ "$code" = "204" ]; } && ok "delete Patient/$pid" || bad "delete Patient/$pid: HTTP $code"
+  else
+    bad "create test Patient: HTTP $code"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+note ""
+note "## Summary: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Investigation and rollout plan for upgrading Smile CDR from 2025.11.R02 (Helm chart 7.1.0) to 2026.05.R01 (Helm chart 9.0.2), per the chart upgrade and migration guides, plus a smoke test script to verify each phase.

Three version levers are involved: the terraform module ref (stays at v9.0.2), `helm_chart_version` (7.1.0 to 9.0.2), and `cdrVersion` (2025.11.R02 to 2026.05.R01).

## Key findings

- Chart v9 supports CDR 2025.05.R01 through 2026.05.R01, so the chart can be bumped first with `cdrVersion` held at 2025.11.R02, isolating packaging changes from the application upgrade.
- Chart target is 9.0.2, not 9.2.0: module v9.1.x/v9.2.0 carry the upstream `_copy_files_node_overlay` plan-breaking bug for multi-node deployments (see commit 348bbf5); still unfixed as of 2026-07-14. 9.0.2/9.0.2 is the matched pair upstream tests, and chart 9.1+/9.2 only adds env vars we do not need.
- The 2025.11 to 2026.05 jump is exactly two GA releases, the maximum allowed in one online upgrade step, so no intermediate stop at 2026.02 is needed.
- Offline renders of charts 7.1.0 and 9.0.2 with the live release values show the only resource-level change is the Ingress rename `smilecdr-scdr` to `smilecdr-scdr-default` (spec identical); the rendered CDR properties are functionally identical.
- The v7 to v8 (Gateway API default) and v8 to v9 (Strimzi KRaft) breaking changes do not apply: nginx-ingress is explicitly pinned and no Kafka/Strimzi is deployed.
- Main application-level risks: the custom AUPS generator jars depend on HAPI JPA IPS internals (verified via $summary smoke test, rebuild path documented), and the 2026.05 GraalVM script sandbox (smart-post-authorize.js audited clean, SMART flows in the test plan).
- Aurora Postgres 14.20 remains supported by 2026.05 (v12 minimum, v16 recommended).

## Changes

- `docs/smilecdr-2026.05-upgrade-plan.md`: findings, risk register, two-phase rollout with rollback paths, verification plan.
- `scripts/upgrade_smoke_tests.sh`: read-only smoke suite (baseline and post-phase), with optional `--write` round-trip and `--expect-version` assertion.

## Baseline (2026-07-14, 2025.11.R02)

Full authenticated run: 30 passed, 1 failed. The failure is pre-existing and unrelated to the upgrade: hl7au returns 404 on its whole smartauth context path (SMART outbound module not live on that node). $summary works on both aucore and ereq pre-upgrade, so post-upgrade AUPS breakage will be attributable.

## Rollout (after this PR)

1. Phase 0: Aurora snapshot (baseline smoke run already captured).
2. Phase 1 PR: `helm_chart_version` 7.1.0 to 9.0.2 (module ref unchanged).
3. Phase 2 PR: `cdrVersion` 2026.05.R01.

Each phase goes through the existing plan-on-PR and gated apply workflow.