### PR TITLE
Bump smilecdr helm chart 7.1.0 to 9.0.2 (Smile CDR unchanged)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,12 @@ module "smile_cdr_dependencies" {
   eks_cluster_name       = var.cluster_name
   cdr_regcred_secret_arn = var.cdr_regcred_secret_arn
   prod_mode              = false
-  helm_chart_version     = "7.1.0"
+  # Chart 9.0.2 pairs with the module tag above (the module stays on v9.0.2:
+  # the v9.1.x/v9.2.0 module releases break plan for multi-node copyFiles, see
+  # docs/smilecdr-2026.05-upgrade-plan.md). Chart v9 supports Smile CDR
+  # 2025.05.R01 through 2026.05.R01; cdrVersion stays pinned independently in
+  # module-config/values-common.yaml.
+  helm_chart_version = "9.0.2"
 
 
   helm_chart_values = [                                                                            #alpha order


### PR DESCRIPTION
Phase 1 of the Smile CDR 2026.05 upgrade (plan: #67).

## What

One line: `helm_chart_version` 7.1.0 to 9.0.2. The module ref stays `v9.0.2` (module v9.1.x/v9.2.0 break plan for multi-node copyFiles) and `cdrVersion` stays pinned at 2025.11.R02, so the running Smile CDR release does not change.

## Expected plan surface

- Ingress `smilecdr-scdr` replaced by `smilecdr-scdr-default` (legacy resource suffix removed in chart v9; spec byte-identical, no TLS block, nginx reconciles in seconds).
- Node Deployments: reworked S3 copyFiles init container (`filecopy.sh` script, aws-cli 2.13 to 2.33), ConfigMap hash roll (one sequential pod restart per node).
- Rendered `Master.properties` functionally identical (verified offline with the live release values).
- Expected NOT to appear: any change to RDS, IAM, Route53, or CDR module config.

## Verification

Baseline smoke run captured 2026-07-14 (30 pass, 1 known pre-existing hl7au smartauth 404). After apply, rerun `scripts/upgrade_smoke_tests.sh --expect-version 2025.11.R02`: expect the same results, and confirm the renamed Ingress serves all context paths.

## Rollback

Revert this PR and re-apply. No data or schema involvement.

Pre-upgrade Aurora snapshot: `smile-pre-upgrade-2026-05-phase0`.