### PR TITLE
Upgrade Smile CDR 2025.11.R02 to 2026.05.R01

### DIFF
--- a/module-config/values-common.yaml
+++ b/module-config/values-common.yaml
@@ -4,10 +4,9 @@ specs:
 # Pin the Smile CDR application version explicitly rather than inheriting the
 # Helm chart's appVersion default. This decouples the Smile CDR version from the
 # chart version so a future helm_chart_version bump does not silently change the
-# running Smile CDR release. Set to the version currently deployed (chart 7.1.0
-# default), so pinning is a no-op for the running image. Bump this deliberately
-# when upgrading Smile CDR.
-cdrVersion: "2025.11.R02"
+# running Smile CDR release. Bump this deliberately when upgrading Smile CDR
+# (see docs/smilecdr-2026.05-upgrade-plan.md).
+cdrVersion: "2026.05.R01"
 
 # Raise the ingress-nginx request body size limit above the 1 MiB nginx default so
 # that larger FHIR transaction Bundles (for example AU eRequesting) are not rejected


### PR DESCRIPTION
Phase 2 of the Smile CDR 2026.05 upgrade (plan: #67; phase 1: #68, applied).

## What

One line: `cdrVersion` 2025.11.R02 to 2026.05.R01 in `module-config/values-common.yaml`. The chart (9.0.2) already defaults to this release, so the rendered manifests change only in the image tag and version labels.

## What happens on apply

- Pods roll onto `docker.smilecdr.com/smilecdr:2026.05.R01` one node at a time.
- Each node runs schema migrations at first boot (`db.schema_update_mode: UPDATE`), including the 2026.02 case-sensitive FHIR ID migration. Datasets are small; expect minutes.
- A 2025.11 to 2026.05 jump is exactly two GA releases, the maximum supported in one hop.

## Verification (after apply)

- Watch first-boot logs for migration errors.
- `scripts/upgrade_smoke_tests.sh --expect-version 2026.05.R01`: expect results identical to baseline (30 pass, 1 known pre-existing hl7au smartauth 404), including the two $summary checks that exercise the custom AUPS generator jars (the main compatibility risk).
- Manual: SMART login flow (exercises smart-post-authorize.js under the new GraalVM sandbox), admin console, logs.

## Rollback

Fast path: revert this PR and re-apply (Smile CDR processes tolerate a schema up to two versions ahead). Full path: restore Aurora snapshot `smile-pre-upgrade-2026-05-phase0` and revert.