### PR TITLE
Upgrade Aurora PostgreSQL engine 14.20 to 16.13

### DIFF
--- a/.github/workflows/smile-application.yml
+++ b/.github/workflows/smile-application.yml
@@ -121,43 +121,48 @@ jobs:
             terraform/main.tfplan
             terraform/builds/
 
-      - name: Create String Output
-        id: tf-plan-string
-        run: |
-          TERRAFORM_PLAN=$(terraform show -no-color main.tfplan)
-          delimiter="$(openssl rand -hex 8)"
-          {
-            echo "summary<<${delimiter}"
-            echo "## Terraform Plan Output (smile-app-prod)"
-            echo "<details><summary>Click to expand</summary>"
-            echo ""
-            echo '```terraform'
-            echo "$TERRAFORM_PLAN"
-            echo '```'
-            echo "</details>"
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
-
+      # Render the saved plan for humans. Both consumers read it straight from the
+      # plan file and are size-capped: a large plan (e.g. a major RDS engine
+      # upgrade, which cascades to many dependent resources) otherwise passes the
+      # whole plan as an env var and overflows the runner's arg/env limit (E2BIG,
+      # "Argument list too long"), and would also blow the 65 KB PR-comment and
+      # 1 MB step-summary caps. These steps are cosmetic, so continue-on-error keeps
+      # a rendering failure from failing the gate, which is driven by the plan exit
+      # code and the uploaded tfplan artifact, not by the summary text.
       - name: Publish Terraform Plan to Task Summary
-        env:
-          SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
-        run: echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+        continue-on-error: true
+        run: |
+          {
+            echo "## Terraform Plan Output (smile-app-prod)"
+            echo '```terraform'
+            terraform show -no-color main.tfplan | head -c 900000
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push Terraform Output to PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
-        env:
-          SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const body = `${process.env.SUMMARY}`;
-            github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body
-            })
+            const { execSync } = require('child_process');
+            const full = execSync('terraform show -no-color main.tfplan', {
+              cwd: 'terraform', maxBuffer: 64 * 1024 * 1024,
+            }).toString();
+            const LIMIT = 60000;
+            const truncated = full.length > LIMIT;
+            const plan = truncated ? full.slice(0, LIMIT) : full;
+            const note = truncated
+              ? '\n\n_Plan truncated for this comment; see the job summary or the `tfplan-smile-app-prod` artifact for the full output._'
+              : '';
+            const body = `## Terraform Plan Output (smile-app-prod)\n<details><summary>Click to expand</summary>\n\n\`\`\`terraform\n${plan}\n\`\`\`\n</details>${note}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
 
   terraform-apply:
     name: 'Terraform Apply'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -101,10 +101,16 @@ module "smile_cdr_dependencies" {
     {
       name   = "SmileCluster"
       engine = "aurora-postgresql-serverless-v2"
-      # Pin to the live cluster's engine version. AWS auto-upgraded the DB to 14.20;
-      # Aurora does not support downgrades, so leaving this unset (module default 14.15)
-      # would produce an invalid destroy/replace. See terraform/REMEDIATION.md.
-      engine_version = "14.20"
+      # In-place major upgrade to PostgreSQL 16 (Smile CDR 2026.05 recommends 16;
+      # PG14 community EOL is 2026-11). The pin must match the live version before
+      # the change; Aurora does not support downgrades, so a mismatch produces an
+      # invalid destroy/replace. See terraform/REMEDIATION.md and
+      # docs/aurora-pg16-upgrade-plan.md. allow_major_version_upgrade and
+      # apply_immediately are required for the engine change to run at apply time
+      # rather than the maintenance window; both are safe to leave set.
+      engine_version              = "16.13"
+      allow_major_version_upgrade = true
+      apply_immediately           = true
       serverless_configuration = {
         min_capacity = 0.5
         max_capacity = 4


### PR DESCRIPTION
In-place major version upgrade of the `SmileCluster` Aurora Serverless v2 cluster from PostgreSQL `14.20` to `16.13`, per `docs/aurora-pg16-upgrade-plan.md` (runbook, #71).

## Change

`terraform/main.tf`, `db_instances[0]`:
- `engine_version` `14.20` to `16.13` (highest valid in-place target from 14.20; verified against the live engine on 2026-07-14)
- add `allow_major_version_upgrade = true` and `apply_immediately = true` so the engine change runs at apply time rather than the maintenance window

## Expected plan

An **in-place update** of the RDS cluster and instance resources only. No destroy/replace, no helm changes. A plan showing replacement means STOP (the pin/live-version mismatch trap).

## Pre-flight (done)

- Live engine confirmed `14.20`; valid 16.x targets `16.11`, `16.13`.
- Manual rollback snapshot `smile-pre-pg16-20260714` taken and `available` (engine 14.20).
- Baseline smoke suite captured: 27 passed, 1 failed (the known `hl7au` smartauth `openid-configuration` 404).

## Apply / rollback

Merge, then dispatch `Smile Configuration Deployment` with `confirm_apply: APPLY` in a quiesced window (~10 to 15 min DB unavailability). Post-upgrade: scale pods back, ANALYZE all seven databases, re-run the smoke suite. Rollback is restore-from-snapshot (no engine downgrade exists).