### PR TITLE
Fix test-data workflows: authenticate to ECR instead of job-level container

### DIFF
--- a/.github/workflows/clear-test-data.yml
+++ b/.github/workflows/clear-test-data.yml
@@ -122,15 +122,32 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write # OIDC for ECR login
 
 jobs:
   clear-data:
     name: Clear FHIR Test Data
     runs-on: arc-runner-set
-    container:
-      image: 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
+    # The loader image lives in a private ECR repo. A job-level `container:` is
+    # pulled before any step can authenticate, which fails on arc-runner-set
+    # ("no basic auth credentials"). Authenticate with OIDC first and run the
+    # loader with `docker run` instead.
+    env:
+      LOADER_IMAGE: 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
 
     steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Pull loader image
+        run: docker pull -q "$LOADER_IMAGE"
+
       - name: Resolve inputs
         id: inputs
         run: |
@@ -205,8 +222,10 @@ jobs:
         if: steps.inputs.outputs.delete_mode == 'targeted'
         id: clone
         run: |
-          WORK_DIR="/tmp/fhir-data"
-          mkdir -p "$WORK_DIR"
+          # RUNNER_TEMP lives on the runner's work volume, which the dind
+          # daemon shares, so it can be bind-mounted into the loader container.
+          WORK_DIR="$RUNNER_TEMP/fhir-data"
+          rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
           git clone "${{ steps.inputs.outputs.data_source }}" "$WORK_DIR"
 
           DATA_DIR="$WORK_DIR/${{ steps.inputs.outputs.data_folder }}"
@@ -226,15 +245,16 @@ jobs:
         env:
           FHIR_AUTH_HEADER: ${{ secrets.CSIRO_FHIR_AUTH_64 }}
         run: |
+          # Paths are as seen inside the loader container ($RUNNER_TEMP -> /work)
           ARGS="--mode ${{ steps.inputs.outputs.delete_mode }}"
           ARGS="$ARGS --fhir-url ${{ steps.inputs.outputs.fhir_url }}"
           ARGS="$ARGS --batch-size ${{ steps.inputs.outputs.batch_size }}"
-          ARGS="$ARGS --summary-file /tmp/clear-summary.json"
-          ARGS="$ARGS --github-step-summary $GITHUB_STEP_SUMMARY"
+          ARGS="$ARGS --summary-file /work/clear-summary.json"
+          ARGS="$ARGS --github-step-summary /work/step-summary.md"
 
           # Add data-dir for targeted mode
           if [ "${{ steps.inputs.outputs.delete_mode }}" = "targeted" ]; then
-            ARGS="$ARGS --data-dir ${{ steps.clone.outputs.data_dir }}"
+            ARGS="$ARGS --data-dir /work/fhir-data/${{ steps.inputs.outputs.data_folder }}"
             ARGS="$ARGS --exclude-patterns ${{ steps.inputs.outputs.exclude_patterns }}"
           fi
 
@@ -256,9 +276,14 @@ jobs:
           fi
 
           set +e
-          sparked-test-data-loader clear $ARGS
+          docker run --rm -e FHIR_AUTH_HEADER -v "$RUNNER_TEMP:/work" "$LOADER_IMAGE" clear $ARGS
           EXIT_CODE=$?
           set -e
+
+          # Surface the loader's markdown summary written inside the mount
+          if [ -f "$RUNNER_TEMP/step-summary.md" ]; then
+            cat "$RUNNER_TEMP/step-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [ $EXIT_CODE -eq 0 ]; then
             echo "status=success" >> $GITHUB_OUTPUT
@@ -267,10 +292,10 @@ jobs:
           fi
 
           # Read summary as single-line JSON for output
-          if [ -f /tmp/clear-summary.json ]; then
+          if [ -f "$RUNNER_TEMP/clear-summary.json" ]; then
             DELIMITER="SUMMARY_$(date +%s%N)"
             echo "summary<<${DELIMITER}" >> $GITHUB_OUTPUT
-            cat /tmp/clear-summary.json | tr -d '\n' >> $GITHUB_OUTPUT
+            cat "$RUNNER_TEMP/clear-summary.json" | tr -d '\n' >> $GITHUB_OUTPUT
             echo "" >> $GITHUB_OUTPUT
             echo "${DELIMITER}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/load-test-data.yml
+++ b/.github/workflows/load-test-data.yml
@@ -127,15 +127,32 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write # OIDC for ECR login
 
 jobs:
   load-data:
     name: Load FHIR Test Data
     runs-on: arc-runner-set
-    container:
-      image: 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
+    # The loader image lives in a private ECR repo. A job-level `container:` is
+    # pulled before any step can authenticate, which fails on arc-runner-set
+    # ("no basic auth credentials"). Authenticate with OIDC first and run the
+    # loader with `docker run` instead.
+    env:
+      LOADER_IMAGE: 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
 
     steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Pull loader image
+        run: docker pull -q "$LOADER_IMAGE"
+
       - name: Resolve inputs
         id: inputs
         run: |
@@ -208,8 +225,10 @@ jobs:
       - name: Clone test data repository
         id: clone
         run: |
-          WORK_DIR="/tmp/fhir-data"
-          mkdir -p "$WORK_DIR"
+          # RUNNER_TEMP lives on the runner's work volume, which the dind
+          # daemon shares, so it can be bind-mounted into the loader container.
+          WORK_DIR="$RUNNER_TEMP/fhir-data"
+          rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
           git clone "${{ steps.inputs.outputs.data_source }}" "$WORK_DIR"
 
           DATA_DIR="$WORK_DIR/${{ steps.inputs.outputs.data_folder }}"
@@ -234,14 +253,15 @@ jobs:
           FHIR_USERNAME: ${{ secrets.FHIR_USERNAME }}
           FHIR_PASSWORD: ${{ secrets.FHIR_PASSWORD }}
         run: |
+          # Paths are as seen inside the loader container ($RUNNER_TEMP -> /work)
           ARGS="--method ${{ steps.inputs.outputs.upload_method }}"
           ARGS="$ARGS --fhir-url ${{ steps.inputs.outputs.fhir_url }}"
-          ARGS="$ARGS --data-dir ${{ steps.clone.outputs.data_dir }}"
+          ARGS="$ARGS --data-dir /work/fhir-data/${{ steps.inputs.outputs.data_folder }}"
           ARGS="$ARGS --upload-mode ${{ steps.inputs.outputs.upload_mode }}"
           ARGS="$ARGS --batch-size ${{ steps.inputs.outputs.batch_size }}"
           ARGS="$ARGS --exclude-patterns ${{ steps.inputs.outputs.exclude_patterns }}"
-          ARGS="$ARGS --summary-file /tmp/upload-summary.json"
-          ARGS="$ARGS --github-step-summary $GITHUB_STEP_SUMMARY"
+          ARGS="$ARGS --summary-file /work/upload-summary.json"
+          ARGS="$ARGS --github-step-summary /work/step-summary.md"
 
           if [ "${{ steps.inputs.outputs.dry_run }}" = "true" ]; then
             ARGS="$ARGS --dry-run"
@@ -252,9 +272,17 @@ jobs:
           fi
 
           set +e
-          sparked-test-data-loader load $ARGS
+          docker run --rm \
+            -e FHIR_AUTH_HEADER -e FHIRFLARE_URL -e FHIRFLARE_API_KEY \
+            -e FHIR_USERNAME -e FHIR_PASSWORD \
+            -v "$RUNNER_TEMP:/work" "$LOADER_IMAGE" load $ARGS
           EXIT_CODE=$?
           set -e
+
+          # Surface the loader's markdown summary written inside the mount
+          if [ -f "$RUNNER_TEMP/step-summary.md" ]; then
+            cat "$RUNNER_TEMP/step-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [ $EXIT_CODE -eq 0 ]; then
             echo "status=success" >> $GITHUB_OUTPUT
@@ -263,10 +291,10 @@ jobs:
           fi
 
           # Read summary as single-line JSON for output
-          if [ -f /tmp/upload-summary.json ]; then
+          if [ -f "$RUNNER_TEMP/upload-summary.json" ]; then
             DELIMITER="SUMMARY_$(date +%s%N)"
             echo "summary<<${DELIMITER}" >> $GITHUB_OUTPUT
-            cat /tmp/upload-summary.json | tr -d '\n' >> $GITHUB_OUTPUT
+            cat "$RUNNER_TEMP/upload-summary.json" | tr -d '\n' >> $GITHUB_OUTPUT
             echo "" >> $GITHUB_OUTPUT
             echo "${DELIMITER}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/manage-test-data.yml
+++ b/.github/workflows/manage-test-data.yml
@@ -33,6 +33,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write # required by the called clear/load workflows for ECR OIDC login
 
 # ============================================================================
 # Clear and Load AU Core


### PR DESCRIPTION
The Manage/Clear/Load Test Data workflows have been failing on `arc-runner-set` with `no basic auth credentials` pulling `sparked-test-data-loader` from ECR (surfaced during the 2026.05 upgrade verification, run 29308109073).

## Root cause

A job-level `container:` image is pulled by the runner before any step executes, so there is no opportunity to authenticate to ECR first. The ARC runners have no standing ECR credentials (and giving shared runner infra broad pull creds is the more invasive fix).

## Fix (workflow-side only)

- Steps added before the work starts: `configure-aws-credentials` via OIDC (`vars.AWS_OIDC_ROLE_ARN`, same pattern as the terraform workflows), `amazon-ecr-login`, `docker pull`.
- The loader now runs via `docker run` with env passthrough and `$RUNNER_TEMP` bind-mounted at `/work` (RUNNER_TEMP is on the runner work volume shared with the dind daemon, so mounts resolve; `/tmp` would not).
- Summary files and the loader's markdown step summary are written inside the mount; the step summary is appended to `$GITHUB_STEP_SUMMARY` after the run.
- `id-token: write` added to both reusable workflows and the Manage Test Data caller.
- Issue-comment steps, inputs, and outputs are unchanged.

## Verification

Dry-run dispatch of Clear Test Data from this branch (targeted mode, aucore, dry_run=true): image pulls and the loader runs end to end.