### PR TITLE
Cut smile.sparked-fhir.com DNS over to the Envoy Gateway NLB

### DIFF
--- a/terraform/gateway-dns.tf
+++ b/terraform/gateway-dns.tf
@@ -1,0 +1,50 @@
+# Gateway API migration: DNS for smile.sparked-fhir.com after cutover to Envoy Gateway.
+#
+# Previously the sdh-deps module created this record aliased to the ingress-nginx NLB
+# (ingress_config.public.route53_create_record). That is now false, and this record aliases
+# smile.sparked-fhir.com to the Envoy Gateway NLB provisioned by the AWS Load Balancer
+# Controller in envoy-gateway-system. The Gateway (main-gateway) is created via GitOps in
+# sparked-smile-argo. See docs/gateway-api-migration-plan.md.
+#
+# Cutover note (gapless): to avoid a brief window where the record is absent, adopt the
+# existing record into this resource's state before the first apply rather than letting
+# Terraform destroy-then-create it:
+#   terraform state mv \
+#     'module.smile_cdr_dependencies.aws_route53_record.publicdns["public"]' \
+#     'aws_route53_record.smile_public'
+# The apply then becomes an in-place alias retarget (nginx NLB -> Envoy NLB). Confirm the
+# source address with `terraform state list | grep publicdns` first.
+
+data "aws_route53_zone" "parent" {
+  name         = var.domain
+  private_zone = false
+}
+
+# The Envoy Gateway NLB hostname, read from the Gateway's programmed status. main-gateway is
+# stable once PROGRAMMED (status.addresses[0].value is the LBC-managed NLB DNS name).
+data "kubernetes_resource" "envoy_gateway" {
+  api_version = "gateway.networking.k8s.io/v1"
+  kind        = "Gateway"
+  metadata {
+    name      = "main-gateway"
+    namespace = "default"
+  }
+}
+
+locals {
+  envoy_nlb_hostname = data.kubernetes_resource.envoy_gateway.object.status.addresses[0].value
+}
+
+resource "aws_route53_record" "smile_public" {
+  zone_id = data.aws_route53_zone.parent.zone_id
+  name    = "smile.${var.domain}"
+  type    = "A"
+
+  alias {
+    name = local.envoy_nlb_hostname
+    # Regional canonical hosted zone ID for Network Load Balancers in ap-southeast-2
+    # (the same value the previous ingress-nginx NLB alias used for this record).
+    zone_id                = "ZCT6FZBF4DROD"
+    evaluate_target_health = false
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -199,10 +199,15 @@ module "smile_cdr_dependencies" {
 
   ingress_config = {
     public = {
-      # The live serving ingress is the chart's default slot (rendered as
-      # smilecdr-scdr, class nginx, host smile.sparked-fhir.com). Claim the default
-      # slot with nginx-ingress so the plan reconciles in place rather than
-      # disabling the default ingress and standing up a gateway-api/ALB one.
+      # The chart still renders the nginx Ingress (class nginx, host
+      # smile.sparked-fhir.com) so specs.hostname and the nginx path stay intact and
+      # harmless until ingress-nginx is decommissioned in the infra repo. Traffic is
+      # cut over to the Envoy Gateway purely at the DNS layer.
+      #
+      # route53_create_record is now false: the smile.sparked-fhir.com record is no
+      # longer aliased to the nginx NLB by this module. It is instead managed by
+      # aws_route53_record.smile_public (terraform/gateway-dns.tf), aliased to the
+      # Envoy Gateway NLB. See docs/gateway-api-migration-plan.md (Gateway API migration).
       useDefaultIngress     = true
       ingressType           = "nginx-ingress"
       route53_create_record = local.route53_create_record
@@ -213,7 +218,9 @@ module "smile_cdr_dependencies" {
 }
 
 locals {
-  route53_create_record = true
+  # Gateway API migration: the smile.sparked-fhir.com record is managed outside this
+  # module (aws_route53_record.smile_public) so it can alias the Envoy Gateway NLB.
+  route53_create_record = false
 
   tags = {
     Name       = var.name


### PR DESCRIPTION
Phase 3 (final cutover) of the Gateway API migration. **Do not apply until the cutover window** — this is the production DNS flip.

## What
- `ingress_config.public.route53_create_record` -> false: the sdh-deps module stops managing the `smile.sparked-fhir.com` record. The nginx Ingress stays rendered but unused (removed later when ingress-nginx is decommissioned).
- New `terraform/gateway-dns.tf`: `aws_route53_record.smile_public` aliases `smile.sparked-fhir.com` to the Envoy Gateway NLB, whose hostname is read from the `main-gateway` Gateway status via the kubernetes provider (canonical NLB zone `ZCT6FZBF4DROD` for ap-southeast-2).

## Pre-req verified
The Envoy path is live and the smoke suite via the Envoy NLB is **identical to the nginx baseline** (27 pass / 1 known hl7au failure), including SMART/OIDC, `$summary`, `$validate`, and the ~3 MiB body check. Targets healthy, TLS valid (Let's Encrypt).

## Apply runbook (gapless)
The naive apply would destroy the module's record then create the new one (a few seconds of no record). To avoid that, adopt the existing record into the new resource first:
```
terraform state list | grep publicdns   # confirm the address
terraform state mv \
  'module.smile_cdr_dependencies.aws_route53_record.publicdns["public"]' \
  'aws_route53_record.smile_public'
```
Then run the standard APPLY dispatch — it becomes an in-place alias retarget (nginx NLB -> Envoy NLB).

## Rollback
Revert this PR and re-apply; the alias returns to the nginx NLB (which keeps serving until Phase 4 decommission). Both NLBs serve `smile.sparked-fhir.com` with a valid cert during the window.

## Follow-ups (not in this PR)
- Delete the orphaned Classic ELB `a461e4fb43cdd45fba222e1e4dd0e9c5` (auto-created by the in-tree controller before the LBC annotations applied; harmless but costs).
- Phase 4 (infra repo): `enable_ingress_nginx = false` after a soak.