### PR TITLE
Record aucore multitenancy rollout and parameterize the Phase 0 test script

### DIFF
--- a/docs/multitenancy-demo.md
+++ b/docs/multitenancy-demo.md
@@ -126,4 +126,5 @@ with this information.
   (ids 100, 101). Demo users: disable and lock via the admin console or API.
 - Participant write removal: before-state snapshots of every changed principal are
   retained by the team; each is a single PUT to restore.
-- The DEFAULT tenant, team accounts, aucore, and hl7au were not modified.
+- The DEFAULT tenant data, team accounts, and the hl7au node were not modified.
+  (aucore was subsequently rolled out on 2026-07-15; see the rollout plan execution log.)

--- a/docs/multitenancy-rollout-plan.md
+++ b/docs/multitenancy-rollout-plan.md
@@ -78,6 +78,12 @@ Scope decision (2026-07-13): team-internal accounts (`ADMIN`, `DevTester`, `plac
   - Participant write removal on ereq DEFAULT: `FHIR_ALL_WRITE` and `FHIR_TRANSACTION` stripped from users `ILYA`, `MICHAEL.OSBORNE`, `PATIENT-DASHBOARD` (before-state snapshots retained). No OIDC client on the ereq node carried write permissions, so no client changes were needed.
   - Deferred: `connectathon-backend-02` holds `FHIR_ALL_WRITE` on DEFAULT but is registered on the **aucore** node; it is handled in Phase 3 with the rest of aucore.
   - See `docs/multitenancy-demo.md` for the verified demo walkthrough.
+- **2026-07-15**: aucore rollout executed per the playbook, zero rollout-caused restarts:
+  - The Phase 0 go/no-go matrix was re-run against aucore using the now node-parameterized `scripts/multitenancy_phase0_tests.sh` (`PHASE0_NODE=aucore`); all critical tests passed, including conditional-update isolation with aucore's `match_url_cache` enabled. Note: on aucore the cross-partition reference test is rejected via the client-assigned ID constraint (409) rather than target-not-found (400), a side effect of `client_id_mode: ANY`; the isolation property holds either way.
+  - Tenant `VENDOR-DEMO` (id 101) created on aucore; tenant-scoped `demo-vendor` user created and verified (read/write in tenant, 403 on DEFAULT read and write, anonymous 403 on the tenant).
+  - Participant write removal on aucore DEFAULT (per named confirmation): users `CONNECTATHON-USER-05`, `CONNECTATHON-USER-06`, `ILYA`, `PATIENT-DASHBOARD`, and the deferred OIDC client `connectathon-backend-02` (now `FHIR_ALL_READ` only). `WRITERTEST` kept as a team test account, to be revisited at the workshop. Before-state snapshots retained.
+  - The tenant-aware `smart-post-authorize.js` was confirmed deployed (shipped with the 2026-07-14 helm chart 9.0.2 apply), so SMART tokens on aucore now derive fhirUser URLs from the request audience.
+  - Operational note: OIDC client updates PUT by clientId in the URL path (PUT by pid returns 400).
 
 ## Phase 3: aucore, then hardening
 

--- a/scripts/multitenancy_phase0_tests.sh
+++ b/scripts/multitenancy_phase0_tests.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Phase 0 multitenancy rehearsal against the ereq node (Sparked Dev FHIR Server).
+# Phase 0 multitenancy rehearsal against a Sparked Dev FHIR Server node.
+# Target node comes from PHASE0_NODE (default ereq); results path from PHASE0_RESULTS.
 # Creates a temporary MTTEST partition, verifies isolation properties, then cleans up.
 # Admin credentials are fetched from AWS Secrets Manager at runtime and kept in memory only.
 set -u
 
-BASE="https://smile.sparked-fhir.com/ereq/fhir"
-ADMINJSON="https://smile.sparked-fhir.com/ereq/admin-json"
+NODE="${PHASE0_NODE:-ereq}"
+BASE="https://smile.sparked-fhir.com/$NODE/fhir"
+ADMINJSON="https://smile.sparked-fhir.com/$NODE/admin-json"
 PART_ID=9001
 PART_NAME="MTTEST"
 TESTUSER="mt-phase0-vendor"
@@ -86,7 +88,7 @@ note "- created-in-DEFAULT id: ${T8id:-unknown}"
 
 note ""
 note "## T9: scoped vendor-style user (write $PART_NAME, no DEFAULT access)"
-T9a=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/json" -o /tmp/t9a.json -w "%{http_code}" -X POST "$ADMINJSON/user-management/ereq/local_security" -d "{\"username\":\"$TESTUSER\",\"password\":\"$TESTUSER_PASS\",\"givenName\":\"MTTest\",\"familyName\":\"Phase0\",\"authorities\":[{\"permission\":\"ROLE_FHIR_CLIENT\"},{\"permission\":\"FHIR_CAPABILITIES\"},{\"permission\":\"FHIR_ALL_READ\"},{\"permission\":\"FHIR_ALL_WRITE\"},{\"permission\":\"FHIR_TRANSACTION\"},{\"permission\":\"FHIR_ACCESS_PARTITION_NAME\",\"argument\":\"$PART_NAME\"}]}")
+T9a=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/json" -o /tmp/t9a.json -w "%{http_code}" -X POST "$ADMINJSON/user-management/$NODE/local_security" -d "{\"username\":\"$TESTUSER\",\"password\":\"$TESTUSER_PASS\",\"givenName\":\"MTTest\",\"familyName\":\"Phase0\",\"authorities\":[{\"permission\":\"ROLE_FHIR_CLIENT\"},{\"permission\":\"FHIR_CAPABILITIES\"},{\"permission\":\"FHIR_ALL_READ\"},{\"permission\":\"FHIR_ALL_WRITE\"},{\"permission\":\"FHIR_TRANSACTION\"},{\"permission\":\"FHIR_ACCESS_PARTITION_NAME\",\"argument\":\"$PART_NAME\"}]}")
 T9pid=$(jq -r '.pid // empty' /tmp/t9a.json 2>/dev/null)
 note "- create user: HTTP $T9a (pid: ${T9pid:-unknown})"
 if [ "$T9a" = "200" ] || [ "$T9a" = "201" ]; then
@@ -109,10 +111,10 @@ done
 if [ -n "${T8id:-}" ]; then C=$(acurl -o /dev/null -w "%{http_code}" -X DELETE "$BASE/DEFAULT/Patient/$T8id"); note "- DELETE DEFAULT/Patient/$T8id (conditional-create artifact): HTTP $C"; fi
 if [ -n "${T9cid:-}" ]; then C=$(acurl -o /dev/null -w "%{http_code}" -X DELETE "$BASE/$PART_NAME/Patient/$T9cid"); note "- DELETE $PART_NAME/Patient/$T9cid (vendor write artifact): HTTP $C"; fi
 if [ -n "${T9pid:-}" ]; then
-  C=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -o /tmp/t9del.json -w "%{http_code}" -X DELETE "$ADMINJSON/user-management/ereq/local_security/$T9pid")
+  C=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -o /tmp/t9del.json -w "%{http_code}" -X DELETE "$ADMINJSON/user-management/$NODE/local_security/$T9pid")
   note "- DELETE test user pid $T9pid: HTTP $C"
   if [ "$C" != "200" ] && [ "$C" != "204" ]; then
-    C2=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/json" -o /dev/null -w "%{http_code}" -X PUT "$ADMINJSON/user-management/ereq/local_security/$T9pid" -d "{\"username\":\"$TESTUSER\",\"accountDisabled\":true,\"accountLocked\":true,\"authorities\":[]}")
+    C2=$(curl -s --max-time 30 -u "ADMIN:$ADMIN_PASS" -H "Content-Type: application/json" -o /dev/null -w "%{http_code}" -X PUT "$ADMINJSON/user-management/$NODE/local_security/$T9pid" -d "{\"username\":\"$TESTUSER\",\"accountDisabled\":true,\"accountLocked\":true,\"authorities\":[]}")
     note "- user delete unsupported; disabled+locked instead: HTTP $C2"
   fi
 fi


### PR DESCRIPTION
## Summary

Records the aucore node rollout (per the ADR 0001 playbook, requested follow-on from the ereq pilot) and makes the Phase 0 rehearsal script node-parameterized (PHASE0_NODE env var).

## What was executed on aucore (2026-07-15, zero rollout-caused restarts)

- Phase 0 go/no-go matrix re-run against aucore: all critical tests pass, including conditional-update isolation with aucore's match_url_cache enabled. Cross-partition references reject via the client-assigned ID constraint (409) on aucore rather than target-not-found (400), a side effect of client_id_mode ANY; isolation holds either way.
- VENDOR-DEMO tenant (id 101) created; tenant-scoped demo-vendor user verified: read/write inside the tenant (200/201), 403 on DEFAULT read and write, anonymous 403 on the tenant.
- Participant write removal on aucore DEFAULT, per named confirmation: CONNECTATHON-USER-05, CONNECTATHON-USER-06, ILYA, PATIENT-DASHBOARD, and the previously deferred connectathon-backend-02 client (now FHIR_ALL_READ only). WRITERTEST retained as a team test account pending the architecture workshop. Before-state snapshots retained for one-PUT rollback.
- Confirmed the tenant-aware smart-post-authorize.js is deployed on aucore (shipped with the 2026-07-14 chart 9.0.2 apply), closing the deferred deploy item.

## Operational notes

- OIDC client updates must PUT by clientId in the URL path (PUT by pid returns 400).
- Permission changes take up to ~1 minute to affect cached sessions.