### PR TITLE
Add smart_auth config reconciliation and clean up dead SMART config

### DIFF
--- a/docs/smart-auth-config.md
+++ b/docs/smart-auth-config.md
@@ -1,0 +1,115 @@
+# SMART Auth Configuration
+
+How SMART on FHIR authentication is configured across the Smile CDR nodes,
+where the configuration actually lives at runtime, and how to keep the repo
+and the servers in sync.
+
+## Architecture
+
+Each node (`aucore`, `ereq`, `hl7au`) runs its own set of modules:
+
+| Module | Type | Role |
+|---|---|---|
+| `smart_auth` | `SECURITY_OUT_SMART` | OAuth2/OIDC authorization server at `/<node>/smartauth` |
+| `local_security` | `SECURITY_IN_LOCAL` | User store backing OAuth logins and HTTP basic auth |
+| `fhir_endpoint` | `ENDPOINT_FHIR_REST` | FHIR API; validates bearer tokens via `security.oic.enabled` |
+
+Supporting pieces:
+
+- **Token signing**: `openid.signing.keystore_id = smilecdr-token-signing`
+  (a dedicated keystore, not the built-in `default-keystore`).
+- **Launch context**: `module-config/smart-post-authorize.js` runs at token
+  issuance. It injects patient/encounter context from EHR launch tokens and
+  sets `fhirUser` to the correct Practitioner (Smile CDR otherwise invents a
+  RelatedPerson). Backend service (client credentials) flows are skipped.
+- **Client registration**: GitHub issue template 05 feeds
+  `.github/workflows/register-smart-clients.yml`, which runs
+  `scripts/register_smart_client.py` against the Admin JSON API. Client
+  definitions live in `module-config/connectathon-clients.json`.
+- **Users**: `scripts/manage_smart_users.py` creates users in
+  `local_security` (definitions in `module-config/connectathon-users.json`).
+- **Anonymous access**: deliberately enabled for the public sandbox. The
+  `ANONYMOUS` user has `FHIR_ALL_READ` restricted to the `DEFAULT` partition,
+  so tenant partitions are only reachable with credentials scoped to them.
+
+## Where config lives: the drift model
+
+`simplified-multinode.yaml` sets `config.database: true` for every node, which
+means:
+
+1. The Helm-rendered properties are read **once**, on a node's first boot,
+   to seed the cluster manager database.
+2. From then on, the **database is authoritative**. Admin console edits land
+   in the database. Changes to the Helm values or mapped files do NOT reach a
+   running node, even across pod restarts.
+
+Consequently the repo drifts from reality unless actively reconciled. That is
+what `scripts/sync_smart_auth.py` is for:
+
+```bash
+# See drift (dry-run is the default)
+python scripts/sync_smart_auth.py
+
+# Apply canonical config (restarts smart_auth on the node)
+python scripts/sync_smart_auth.py --apply
+```
+
+The script manages these `smart_auth` options on `aucore` and `ereq`:
+the post-authorize script text (rendered per node so the fallback audience
+points at the node's own FHIR base), the auth request parameter whitelist,
+the signing keystore, CORS, and `smart_capabilities_list` (which is
+multi-line and therefore cannot be seeded safely through the properties
+file; the sync script is its only source of truth).
+
+After changing `smart-post-authorize.js` or the canonical values in the sync
+script, run it with `--apply`. Note the module restart briefly interrupts
+token issuance on that node.
+
+## hl7au is excluded
+
+`hl7au`'s live `smart_auth` predates the per-node layout: it listens at the
+bare `/smartauth` context path with issuer
+`https://smile.sparked-fhir.com/smartauth` and the `default-keystore`, and has
+no post-authorize script. The repo records the intended per-node state
+(`hl7au/smartauth`), but moving the live context path requires coordinated
+ingress changes and is out of scope for config reconciliation. Until that
+move is planned, `sync_smart_auth.py` does not touch `hl7au`.
+
+## appSphere (app_gallery)
+
+appSphere is Smile CDR's SMART app gallery and developer self-service portal
+(module type `APP_GALLERY`). Instances were added via the admin console on
+`aucore` and `ereq` but were never wired up:
+
+- No Kubernetes Service or ingress route exists, so
+  `/<node>/appsphere` returns 404 at the edge; the module serves nobody.
+- The `ereq` instance points at `aucore`'s auth/FHIR/API URLs.
+- Approval notification emails, helpdesk contact, and terms/privacy URLs are
+  all empty.
+
+Client registration is handled by the GitHub issue workflow instead, which is
+auditable and portable. The gallery is redundant with it; archive the unused
+modules with:
+
+```bash
+python scripts/sync_smart_auth.py --archive-app-gallery --apply
+```
+
+If a vendor-facing self-service portal is ever wanted, define the module
+per node in `simplified-multinode.yaml` (so the chart creates the Service and
+ingress route), point each instance at its own node's URLs, and fill in the
+notification and helpdesk fields.
+
+## Known follow-ups
+
+- **Asymmetric client authentication** (`private_key_jwt`, SMART capability
+  `client-confidential-asymmetric`): the modern best practice for SMART
+  Backend Services and the direction AU eRequesting is heading. Requires
+  registering clients with a JWKS (URL or inline) and advertising the
+  capability; `register_smart_client.py` would need a `--jwks-url` option.
+- **SMART v2 granular scopes** (`permission-v2`): not currently advertised;
+  connectathon clients use v1 scopes.
+- **Locked config**: switching nodes from database-backed to locked
+  (properties-authoritative) config would eliminate drift structurally, but
+  is a disruptive migration and removes the admin console as an escape hatch.
+  Revisit if drift keeps recurring despite the sync script.

--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -79,21 +79,19 @@ cdrNodes:
         enabled: true
         config:
           context_path: "aucore/fhirweb"
+      # NOTE: node config is database-backed (config.database: true), so this
+      # block only seeds a first boot. The live smart_auth config is reconciled
+      # from the repo with scripts/sync_smart_auth.py; run its --dry-run to see
+      # drift. smart_capabilities_list is multi-line and is managed solely by
+      # the sync script (properties rendering of multi-line values is unsafe).
       smart_auth:
         name: security_out_smart
         config:
           context_path: "aucore/smartauth"
           auth_request_detail.whitelist: "aud,grant_type,scope,launch"
-          # openid.signing.keystore_id: default-keystore # do later
+          openid.signing.keystore_id: smilecdr-token-signing
           post_authorize_script.file: "classpath:config_seeding/smart-post-authorize.js"
-          cors.enabled: true
-      security_in_smart:
-        name: security_in_smart
-        type: SECURITY_IN_SMART
-        enabled: true
-        config:
-          seed.users.file: "classpath:/config_seeding/smart-users.json"
-          max_failed_logins_until_lock: 20 # Increased from 5 to 20
+          cors.enable: true
   hl7au:
     name: hl7au
     enabled: true
@@ -150,10 +148,15 @@ cdrNodes:
       admin_json:
         config:
           context_path: "hl7au/admin-json"
+      # Live hl7au drift (2026-07-15): the running module sits at bare
+      # /smartauth with issuer https://smile.sparked-fhir.com/smartauth and the
+      # default-keystore, predating the per-node layout. This block records the
+      # intended state; hl7au is deliberately excluded from sync_smart_auth.py
+      # until the context-path/ingress move is planned.
       smart_auth:
         config:
           context_path: "hl7au/smartauth"
-          cors.enabled: true
+          cors.enable: true
       fhirweb_endpoint:
         enabled: true
         config:
@@ -252,10 +255,16 @@ cdrNodes:
       admin_json:
         config:
           context_path: "ereq/admin-json"
+      # See the aucore smart_auth note: database-backed config, reconciled by
+      # scripts/sync_smart_auth.py. The sync script rewrites the fallback
+      # audience in smart-post-authorize.js to this node's FHIR base.
       smart_auth:
         config:
           context_path: "ereq/smartauth"
-          cors.enabled: true
+          auth_request_detail.whitelist: "aud,grant_type,scope,launch"
+          openid.signing.keystore_id: smilecdr-token-signing
+          post_authorize_script.file: "classpath:config_seeding/smart-post-authorize.js"
+          cors.enable: true
       fhirweb_endpoint:
         enabled: true
         config:

--- a/module-config/smart-post-authorize.js
+++ b/module-config/smart-post-authorize.js
@@ -17,6 +17,13 @@
  * Config key: post_authorize_script.file (SMART Outbound Security module)
  * Docs: https://smilecdr.com/docs/smart/user_profile.html
  */
+
+// Fallback audience when neither getAudience() nor the whitelisted "aud"
+// request parameter yields a value (some standalone launches). This base is
+// node-specific: scripts/sync_smart_auth.py rewrites the node segment when
+// pushing this script to each node, so keep the URL on a single line.
+var DEFAULT_AUDIENCE_BASE = "https://smile.sparked-fhir.com/aucore/fhir/DEFAULT";
+
 function onTokenGenerating(theUserSession, theAuthorizationRequestDetails) {
     // Client Credentials (backend service) flows have no user session: there is
     // no user, launch context, or fhirUser to inject. Skip all user-oriented
@@ -40,7 +47,7 @@ function onTokenGenerating(theUserSession, theAuthorizationRequestDetails) {
         }
     }
     if (!audience) {
-        audience = "https://smile.sparked-fhir.com/aucore/fhir/DEFAULT";
+        audience = DEFAULT_AUDIENCE_BASE;
     }
     // Normalise trailing slashes: URLs are built as audience + "/Practitioner/..."
     audience = ("" + audience).replace(/\/+$/, "");

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -169,6 +169,35 @@ See [SMART App Registration Guide](../docs/SMART-APP-REGISTRATION.md) for the fu
 
 ---
 
+## SMART Auth Config Reconciliation
+
+Node module config is database-backed, so console edits drift from the repo.
+`sync_smart_auth.py` diffs the canonical `smart_auth` config (including
+`module-config/smart-post-authorize.js`) against the live Admin JSON API and
+applies the differences. See [SMART Auth Configuration](../docs/smart-auth-config.md)
+for the full drift model.
+
+```bash
+export CSIRO_FHIR_AUTH_64="your_base64_credentials"
+
+# Show drift on all supported nodes (dry-run is the default)
+python scripts/sync_smart_auth.py
+
+# Apply to all supported nodes (restarts the smart_auth module)
+python scripts/sync_smart_auth.py --apply
+
+# Single node
+python scripts/sync_smart_auth.py --apply --node ereq
+
+# Also archive the unused appSphere (app_gallery) module
+python scripts/sync_smart_auth.py --archive-app-gallery --apply
+```
+
+Applying restarts `smart_auth` on the target node, briefly interrupting token
+issuance and OAuth logins there. Run it outside connectathon hours.
+
+---
+
 ## Package Synchronization
 
 ### Files

--- a/scripts/sync_smart_auth.py
+++ b/scripts/sync_smart_auth.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+SMART Auth Module Config Reconciliation
+
+Node module config is database-backed (config.database: true in
+module-config/simplified-multinode.yaml), so console edits are authoritative
+at runtime and the Helm values only seed a first boot. This script makes the
+repo the source of truth again: it diffs the canonical smart_auth
+configuration (including module-config/smart-post-authorize.js) against the
+live Admin JSON API and applies the differences.
+
+Canonical configuration per node:
+    post_authorize_script.text   rendered from module-config/smart-post-authorize.js
+                                 with the DEFAULT_AUDIENCE_BASE node segment
+                                 rewritten to the target node
+    post_authorize_script.file   cleared (the DB-stored text is authoritative;
+                                 the classpath file only serves first-boot seeding)
+    auth_request_detail.whitelist aud,grant_type,scope,launch
+    openid.signing.keystore_id   smilecdr-token-signing
+    cors.enable                  true
+    smart_capabilities_list      SMART capability advertisement, including
+                                 context-ehr-encounter (the launch script
+                                 injects encounter context)
+
+hl7au is deliberately excluded: its live smart_auth predates the per-node
+layout (bare /smartauth context path, default-keystore). See
+docs/smart-auth-config.md.
+
+API Reference:
+    https://smilecdr.com/docs/json_admin_endpoints/module_config_endpoint.html
+    GET    /module-config/{nodeId}/{moduleId}          - Fetch module config
+    PUT    /module-config/{nodeId}/{moduleId}/set      - Update config (?restart=true)
+    POST   /module-config/{nodeId}/{moduleId}/stop     - Stop module
+    DELETE /module-config/{nodeId}/{moduleId}/archive  - Archive module
+
+Usage:
+    # Show drift without changing anything (default)
+    python sync_smart_auth.py
+
+    # Apply the canonical config to all supported nodes (restarts smart_auth)
+    python sync_smart_auth.py --apply
+
+    # Single node
+    python sync_smart_auth.py --apply --node ereq
+
+    # Archive the unused appSphere module (see docs/smart-auth-config.md)
+    python sync_smart_auth.py --archive-app-gallery --apply
+
+Environment Variables:
+    CSIRO_FHIR_AUTH_64: Base64 encoded basic auth credentials (admin account).
+        Build from AWS Secrets Manager with:
+        export CSIRO_FHIR_AUTH_64=$(printf 'ADMIN:%s' "$(aws secretsmanager \\
+            get-secret-value --secret-id smilecdr-user-passwords \\
+            --query SecretString --output text | jq -r \\
+            '."smilecdr-admin-password"')" | base64)
+    SMILECDR_BASE_URL: Base URL (default: https://smile.sparked-fhir.com)
+
+Note: applying restarts the smart_auth module on the target node, which
+briefly interrupts token issuance and OAuth logins on that node.
+"""
+
+import argparse
+import difflib
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+except ImportError:
+    print("Error: 'requests' library is required. Install with: pip install requests")
+    sys.exit(1)
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+DEFAULT_BASE_URL = "https://smile.sparked-fhir.com"
+MODULE_ID = "smart_auth"
+APP_GALLERY_MODULE_ID = "app_gallery"
+SUPPORTED_NODES = ["aucore", "ereq"]
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "module-config" / "smart-post-authorize.js"
+
+# The node segment in this URL is rewritten per node when rendering the script.
+AUCORE_AUDIENCE_BASE = f"{DEFAULT_BASE_URL}/aucore/fhir/DEFAULT"
+
+AUTH_REQUEST_WHITELIST = "aud,grant_type,scope,launch"
+SIGNING_KEYSTORE_ID = "smilecdr-token-signing"
+
+# SMART capability advertisement (.well-known/smart-configuration).
+# context-ehr-encounter is included because smart-post-authorize.js injects
+# encounter launch context. Multi-line, so managed here rather than in the
+# Helm values (properties rendering of multi-line values is unsafe).
+SMART_CAPABILITIES = [
+    "launch-ehr",
+    "launch-standalone",
+    "client-public",
+    "client-confidential-symmetric",
+    "context-ehr-patient",
+    "context-ehr-encounter",
+    "context-standalone-patient",
+    "sso-openid-connect",
+    "permission-patient",
+    "permission-offline",
+]
+
+
+def render_post_authorize_script(node: str) -> str:
+    """Render smart-post-authorize.js for a node.
+
+    Rewrites the DEFAULT_AUDIENCE_BASE node segment so standalone launches
+    with no resolvable audience mint fhirUser URLs against the node's own
+    FHIR base rather than aucore's.
+    """
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    if AUCORE_AUDIENCE_BASE not in text:
+        print(f"FATAL: expected audience base '{AUCORE_AUDIENCE_BASE}' not found in {SCRIPT_PATH}")
+        sys.exit(1)
+    node_base = f"{DEFAULT_BASE_URL}/{node}/fhir/DEFAULT"
+    return text.replace(AUCORE_AUDIENCE_BASE, node_base)
+
+
+def desired_options(node: str) -> Dict[str, str]:
+    """Canonical smart_auth option values for a node.
+
+    Keys not listed here are left exactly as they are on the server.
+    """
+    return {
+        "post_authorize_script.text": render_post_authorize_script(node),
+        "post_authorize_script.file": "",
+        "auth_request_detail.whitelist": AUTH_REQUEST_WHITELIST,
+        "openid.signing.keystore_id": SIGNING_KEYSTORE_ID,
+        "cors.enable": "true",
+        "smart_capabilities_list": "\n".join(SMART_CAPABILITIES),
+    }
+
+
+# =============================================================================
+# HTTP
+# =============================================================================
+
+def create_session(auth_header: str) -> requests.Session:
+    session = requests.Session()
+    retry = Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    session.headers.update({
+        "Content-Type": "application/json",
+        "Authorization": f"Basic {auth_header}",
+    })
+    return session
+
+
+class ModuleConfigClient:
+    """Thin wrapper over the SmileCDR Admin JSON module-config endpoint."""
+
+    def __init__(self, base_url: str, auth_header: str, node: str):
+        self.node = node
+        self.admin_url = f"{base_url.rstrip('/')}/{node}/admin-json"
+        self.session = create_session(auth_header)
+
+    def _module_url(self, module_id: str, suffix: str = "") -> str:
+        return f"{self.admin_url}/module-config/{self.node}/{module_id}{suffix}"
+
+    def get_module(self, module_id: str) -> Optional[Dict]:
+        resp = self.session.get(self._module_url(module_id), timeout=30)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    def set_module_options(self, module_id: str, options: List[Dict], restart: bool) -> None:
+        """PUT the full options list back (fetch-modify-put, never a partial list)."""
+        suffix = "/set?restart=true" if restart else "/set"
+        resp = self.session.put(
+            self._module_url(module_id, suffix),
+            json={"options": options},
+            timeout=60,
+        )
+        resp.raise_for_status()
+
+    def stop_module(self, module_id: str) -> None:
+        resp = self.session.post(self._module_url(module_id, "/stop"), timeout=60)
+        resp.raise_for_status()
+
+    def archive_module(self, module_id: str) -> None:
+        resp = self.session.delete(self._module_url(module_id, "/archive"), timeout=60)
+        resp.raise_for_status()
+
+
+# =============================================================================
+# Reconciliation
+# =============================================================================
+
+def summarize_change(key: str, live: str, desired: str) -> str:
+    if "\n" in desired or "\n" in live:
+        diff = list(difflib.unified_diff(
+            live.splitlines(), desired.splitlines(), lineterm="", n=0,
+        ))
+        changed = len([l for l in diff if l[:1] in "+-" and l[:3] not in ("+++", "---")])
+        return f"{key}: multi-line value differs ({changed} changed lines)"
+    live_disp = live if live else "(empty)"
+    desired_disp = desired if desired else "(empty)"
+    return f"{key}: {live_disp!r} -> {desired_disp!r}"
+
+
+def reconcile_node(client: ModuleConfigClient, node: str, apply: bool, restart: bool) -> bool:
+    """Diff and optionally apply canonical smart_auth config. Returns True if in sync or applied."""
+    print(f"\n=== {node}/{MODULE_ID} ===")
+    module = client.get_module(MODULE_ID)
+    if module is None:
+        print(f"  [FAIL] module {MODULE_ID} not found on node {node}")
+        return False
+
+    options: List[Dict] = module.get("options", [])
+    live = {opt["key"]: opt.get("value") or "" for opt in options}
+    desired = desired_options(node)
+
+    changes = {k: v for k, v in desired.items() if live.get(k, "") != v}
+    if not changes:
+        print("  In sync, nothing to do.")
+        return True
+
+    for key, value in changes.items():
+        print("  " + summarize_change(key, live.get(key, ""), value))
+
+    if not apply:
+        print(f"  [DRY RUN] {len(changes)} option(s) would be updated. Re-run with --apply.")
+        return True
+
+    known_keys = {opt["key"] for opt in options}
+    for opt in options:
+        if opt["key"] in changes:
+            opt["value"] = changes[opt["key"]]
+    for key, value in changes.items():
+        if key not in known_keys:
+            options.append({"key": key, "value": value})
+
+    client.set_module_options(MODULE_ID, options, restart=restart)
+    restart_note = "module restarting" if restart else "restart deferred (--no-restart)"
+    print(f"  [OK] {len(changes)} option(s) updated, {restart_note}.")
+    return True
+
+
+def archive_app_gallery(client: ModuleConfigClient, node: str, apply: bool) -> bool:
+    """Stop and archive the appSphere module if present. Returns True on success/no-op."""
+    print(f"\n=== {node}/{APP_GALLERY_MODULE_ID} ===")
+    module = client.get_module(APP_GALLERY_MODULE_ID)
+    if module is None:
+        print("  Not present, nothing to do.")
+        return True
+
+    if not apply:
+        print("  [DRY RUN] Would stop and archive this module. Re-run with --apply.")
+        return True
+
+    client.stop_module(APP_GALLERY_MODULE_ID)
+    client.archive_module(APP_GALLERY_MODULE_ID)
+    print("  [OK] Stopped and archived.")
+    return True
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconcile live smart_auth module config with the repo",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--node", choices=SUPPORTED_NODES, action="append",
+                        help="Node(s) to reconcile (default: all supported nodes)")
+    parser.add_argument("--apply", action="store_true",
+                        help="Apply changes (default is a dry-run diff)")
+    parser.add_argument("--no-restart", action="store_true",
+                        help="Update config without restarting the module "
+                             "(changes take effect on the next restart)")
+    parser.add_argument("--archive-app-gallery", action="store_true",
+                        help="Also stop and archive the unused appSphere (app_gallery) module")
+    parser.add_argument("--base-url", default=os.environ.get("SMILECDR_BASE_URL", DEFAULT_BASE_URL),
+                        help="Base URL (default: SMILECDR_BASE_URL env or %(default)s)")
+    parser.add_argument("--auth-64", default=os.environ.get("CSIRO_FHIR_AUTH_64"),
+                        help="Base64 encoded basic auth credentials "
+                             "(default: CSIRO_FHIR_AUTH_64 env var)")
+    args = parser.parse_args()
+
+    if not args.auth_64:
+        print("Error: no credentials. Set CSIRO_FHIR_AUTH_64 or pass --auth-64.")
+        return 1
+
+    nodes = args.node or SUPPORTED_NODES
+    if not args.apply:
+        print("Dry-run mode: no changes will be made.")
+
+    ok = True
+    for node in nodes:
+        client = ModuleConfigClient(args.base_url, args.auth_64, node)
+        try:
+            ok &= reconcile_node(client, node, apply=args.apply, restart=not args.no_restart)
+            if args.archive_app_gallery:
+                ok &= archive_app_gallery(client, node, apply=args.apply)
+        except requests.RequestException as e:
+            print(f"  [ERROR] {node}: {e}")
+            ok = False
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Node module config is database-backed (`config.database: true`), so admin console edits are authoritative at runtime and the Helm values only seed a first boot. An audit on 2026-07-15 (repo vs live Admin JSON API) found the two had drifted:

- Both aucore and ereq run an older `post_authorize_script.text` than `module-config/smart-post-authorize.js` (missing the aud request-parameter fallback and trailing-slash normalisation), and both hardcode the fallback audience to aucore's FHIR base, which is wrong on ereq.
- The repo's `security_in_smart` block never took effect: the module exists on no live node and its seed file (`smart-users.json`) does not exist. SMART users actually live in `local_security`.
- `openid.signing.keystore_id = smilecdr-token-signing` is live on both nodes but was commented "do later" in the repo.
- `cors.enabled` is not a valid Smile CDR property (the real key is `cors.enable`), so the repo seed value was silently ignored.
- Unrouted `app_gallery` (appSphere) modules exist on aucore and ereq: no Service/ingress (404 at the edge), the ereq instance points at aucore's URLs, and client registration is already handled by the GitHub issue workflow.

## What

- **`scripts/sync_smart_auth.py`**: reconciles canonical `smart_auth` config against the live Admin JSON API. Dry-run by default; `--apply` fetch-modify-puts the full options list and restarts the module. Renders `smart-post-authorize.js` per node so the fallback audience points at the node's own FHIR base. `--archive-app-gallery` stops and archives the unused appSphere modules. Manages `smart_capabilities_list` (now including `context-ehr-encounter`, since the launch script injects encounter context); the list is multi-line and cannot be seeded safely through the properties file.
- **`module-config/simplified-multinode.yaml`**: remove the dead `security_in_smart` block, set the signing keystore on aucore and ereq, bring ereq's `smart_auth` seed to parity with aucore, fix `cors.enabled` to `cors.enable`, and document hl7au's legacy bare `/smartauth` layout (excluded from sync until an ingress move is planned).
- **`module-config/smart-post-authorize.js`**: hoist the fallback audience into a marked `DEFAULT_AUDIENCE_BASE` constant for per-node rendering.
- **`docs/smart-auth-config.md`**: SMART auth architecture, the drift model, the appSphere situation, and follow-ups (asymmetric client auth, SMART v2 scopes, locked config).

## Validation

Dry-run against the live nodes matches the audit findings exactly: on both aucore and ereq only the post-authorize script and capability list differ; whitelist, keystore, and CORS are already in sync.

```
=== aucore/smart_auth ===
  post_authorize_script.text: multi-line value differs (28 changed lines)
  smart_capabilities_list: multi-line value differs (3 changed lines)
=== ereq/smart_auth ===
  post_authorize_script.text: multi-line value differs (28 changed lines)
  smart_capabilities_list: multi-line value differs (3 changed lines)
```

`--apply` (and app_gallery archival) has NOT been run; that is a follow-up operational step after this merges. Applying restarts `smart_auth` on the target node, briefly interrupting token issuance.