### PR TITLE
Add patient-contribution resource types to the ereq whitelist

### DIFF
--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -179,7 +179,7 @@ cdrNodes:
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
           package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-au-erequesting-1.0.0.json classpath:/config_seeding/package-aucore-2.1.0-draft.json classpath:/config_seeding/package-international-patient-summary-2.0.0.json"
-          resource_types.supported.whitelist: "Medication,AllergyIntolerance,MedicationRequest,Immunization,HealthcareService, Specimen,MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,CodeSystem,ValueSet,ServiceRequest,Task,Organization,Location,Patient,Practitioner,PractitionerRole,Encounter,Coverage,Condition,DocumentReference,Observation,Procedure,RelatedPerson"
+          resource_types.supported.whitelist: "Medication,AllergyIntolerance,MedicationRequest,Immunization,HealthcareService, Specimen,MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,CodeSystem,ValueSet,ServiceRequest,Task,Organization,Location,Patient,Practitioner,PractitionerRole,Encounter,Coverage,Condition,DocumentReference,Observation,Procedure,RelatedPerson,Communication,Provenance,Questionnaire,QuestionnaireResponse"
           metadata.resource_counts.enabled: false
           validator.local_reference_policy: "NOT_VALIDATED"
           validator.unknown_codesystem_validation_policy: "GENERATE_WARNING"


### PR DESCRIPTION
## What

Appends `Communication`, `Provenance`, `Questionnaire`, `QuestionnaireResponse` to the ereq node's `resource_types.supported.whitelist`. Additive only; no existing type is removed and aucore/hl7au are untouched.

## Why

Patient-authored writeback flows against the PLATYPUS demo tenant (partition 102, created per the multitenancy rollout) submit transaction bundles that carry a `Communication` and a patient `Provenance` alongside the tracked `Task`; the questionnaire return leg also posts a `QuestionnaireResponse` and reads the requesting `Questionnaire`. The ereq whitelist currently rejects those entries with `HAPI-0302 Unknown resource type`, which blocks two of the three demo flows (the single-resource `DocumentReference` note flow already works).

## Impact

- All ereq tenants gain these four types; partition isolation still applies per resource.
- Deploy rolls the ereq pod per the normal config path.