### PR TITLE
Add local terraform deploy runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Test data management is powered by the [`sparked-test-data-loader`](https://gith
 | **[Workflow Guide](docs/WORKFLOWS.md)** | Complete guide to all automated workflows | Everyone |
 | **[SMART App Registration](docs/SMART-APP-REGISTRATION.md)** | Register SMART on FHIR / OIDC clients | Developers/Participants |
 | **[Scripts README](scripts/README.md)** | How to use Python scripts locally | Developers/Admins |
+| **[Terraform Local Deploy](docs/terraform-local-deploy.md)** | Plan/apply the infrastructure from a workstation (terraform is local-only) | Admins |
 
 ## Architecture
 
@@ -207,7 +208,7 @@ python scripts/update_node_packages.py \
   --package package-example.json \
   --dry-run
 
-# Set up Terraform
+# Set up Terraform (see docs/terraform-local-deploy.md for the full deploy runbook)
 cd terraform
 cp terraform.tfvars.example terraform.tfvars   # Edit with your values
 cp backend.hcl.example backend.hcl             # Edit with your S3 bucket
@@ -222,6 +223,11 @@ cd ..
 yamllint module-config/*.yaml
 find module-config/packages -name "*.json" -exec jq empty {} \;
 ```
+
+> Terraform is applied **locally, not in CI**. For the full deploy procedure
+> (prerequisites, safety snapshot, plan review, apply, verification, rollback) see
+> [`docs/terraform-local-deploy.md`](docs/terraform-local-deploy.md). For recovering from
+> module/provider drift, see [`terraform/REMEDIATION.md`](terraform/REMEDIATION.md).
 
 ### Reproducing this setup in your own AWS account
 
@@ -361,8 +367,8 @@ The following GitHub configuration is required for CI/CD workflows:
 > `terraform plan`/`apply` against live infrastructure in a public repo would publish
 > plan output (secret ARNs, resource IDs, topology) to PR comments, job summaries,
 > artifacts, and run logs. Apply from a workstation with the gitignored
-> `terraform/backend.hcl` and `terraform/terraform.tfvars`. See
-> [`terraform/REMEDIATION.md`](terraform/REMEDIATION.md).
+> `terraform/backend.hcl` and `terraform/terraform.tfvars`, following the deploy runbook
+> [`docs/terraform-local-deploy.md`](docs/terraform-local-deploy.md).
 
 ### Repository Secrets (Settings > Secrets and variables > Actions > Secrets)
 

--- a/docs/ci-deploy-enablement.md
+++ b/docs/ci-deploy-enablement.md
@@ -1,5 +1,11 @@
 # CI deploy enablement, scope of work
 
+> **SUPERSEDED (2026-07-16).** This document analysed moving terraform apply into CI. That
+> direction was reversed when the repository went public: running terraform against live
+> infrastructure in a public repo leaks plan output. Terraform is now applied locally only,
+> and `smile-application.yml` is disabled. This file is retained for historical context.
+> For the current deploy process see [`terraform-local-deploy.md`](terraform-local-deploy.md).
+
 Goal: get the `Smile Configuration Deployment` workflow (`.github/workflows/smile-application.yml`)
 to reliably plan on PRs and apply on merge to `main`, replacing local `terraform apply`.
 

--- a/docs/terraform-local-deploy.md
+++ b/docs/terraform-local-deploy.md
@@ -1,0 +1,128 @@
+# Terraform local deploy runbook
+
+How to plan and apply the Sparked Smile CDR infrastructure from a workstation.
+
+**Terraform is applied locally, not in CI.** The `Smile Configuration Deployment`
+workflow (`.github/workflows/smile-application.yml`) is intentionally disabled: running
+`terraform plan`/`apply` against live infrastructure in a public repository would publish
+plan output (secret ARNs, resource IDs, topology) to PR comments, job summaries,
+artifacts, and run logs. All real deploys are done from a workstation with the gitignored
+`terraform/backend.hcl` and `terraform/terraform.tfvars`.
+
+For a one-off recovery from module or provider drift (version bumps, resource
+replacements, state surgery), use [`../terraform/REMEDIATION.md`](../terraform/REMEDIATION.md)
+instead; this document covers the normal, steady-state deploy.
+
+## Prerequisites
+
+- **Terraform** `1.15.6` (the `smile_cdr_dependencies` module requires `>= 1.14.3, < 2.0.0`;
+  the root `provider.tf` only pins `>= 1.5`, but the module constraint is the binding one).
+- **AWS credentials** for the Sparked AWS account (region `ap-southeast-2`), typically via
+  AWS SSO with admin access. Confirm with `aws sts get-caller-identity`.
+- **The two gitignored config files present in `terraform/`** with real values (see one-time
+  setup below):
+  - `backend.hcl`, the S3 state bucket name. State lives at key `infra/smile-app/prod.tfstate`.
+  - `terraform.tfvars`, the three no-default variables: `s3_bucket_name`,
+    `cdr_regcred_secret_arn`, `smilecdr_iam_role_name`.
+- **kubectl** (optional, for verification only). Terraform authenticates to EKS through the
+  module's data sources, so it ignores your local kubectl context. For direct `kubectl`
+  against the cluster, use `--context sparked-smile`.
+
+## One-time setup
+
+```bash
+cd terraform
+cp backend.hcl.example backend.hcl              # set the real state bucket name
+cp terraform.tfvars.example terraform.tfvars    # set s3_bucket_name, cdr_regcred_secret_arn, smilecdr_iam_role_name
+terraform init -backend-config=backend.hcl
+```
+
+Both files are gitignored (`.gitignore`) and must never be committed.
+
+## Normal deploy
+
+### 1. Take a safety snapshot
+
+Aurora cannot be downgraded and some changes cascade to database resources. Before any
+apply, snapshot the Smile Aurora cluster and wait until it is `available`:
+
+```bash
+aws rds create-db-cluster-snapshot \
+  --db-cluster-identifier <smile-aurora-cluster-id> \
+  --db-cluster-snapshot-identifier smile-pre-apply-$(date +%Y%m%d-%H%M) \
+  --region ap-southeast-2
+```
+
+Pick a low-usage window; brief downtime is acceptable (the server is used mainly during events).
+
+### 2. Init and plan
+
+```bash
+cd terraform
+terraform init -backend-config=backend.hcl   # re-run after module/provider changes; add -upgrade to bump
+terraform plan -out main.tfplan
+```
+
+### 3. Review the plan
+
+Read the plan before applying. The bar for a steady-state change is:
+
+- **Zero destroys**, and only the in-place changes you intended.
+- No Aurora engine version change (Aurora cannot downgrade; if you see one, stop and reconcile).
+- No replacement of the KMS secrets alias or the `smilecdr-users-json` / DB-user secrets.
+
+If the plan shows unexpected destroys or replacements, do not apply. That is drift; follow
+[`../terraform/REMEDIATION.md`](../terraform/REMEDIATION.md).
+
+### 4. Apply
+
+```bash
+terraform apply main.tfplan
+```
+
+### 5. Verify
+
+```bash
+# Both nodes serve their CapabilityStatement
+curl -sf https://smile.sparked-fhir.com/aucore/fhir/DEFAULT/metadata > /dev/null && echo "aucore ok"
+curl -sf https://smile.sparked-fhir.com/ereq/fhir/DEFAULT/metadata   > /dev/null && echo "ereq ok"
+```
+
+Ingress body-size cap (expect `403`/`413` around the 16 MiB limit; anonymous, non-persisting):
+
+```bash
+for kb in 1100 15000 17000; do
+  b=$((kb*1024))
+  python3 -c "import sys;sys.stdout.write('{\"resourceType\":\"Bundle\",\"type\":\"transaction\",\"_pad\":\"'+'x'*($b-60)+'\"}')" > /tmp/pb.json
+  curl -s -o /dev/null -w "${kb}KB -> %{http_code}\n" -m 120 -X POST \
+    -H "Content-Type: application/fhir+json" --data @/tmp/pb.json \
+    https://smile.sparked-fhir.com/ereq/fhir/DEFAULT
+done
+# Expect: 1100KB and 15000KB -> 403 (through nginx), 17000KB -> 413 (over the 16 MiB cap)
+```
+
+Also confirm the auth flows still work: `client_credentials` for the
+`consultmed-ereq-backend` client, and the `smart_auth` interactive login flow.
+
+If verification fails, roll back (below).
+
+## Rollback
+
+1. Restore the Aurora cluster from the pre-apply snapshot taken in step 1.
+2. Revert the offending change in the repo (for a module or provider version change, revert
+   the pinned ref) and re-`apply` the previous good plan.
+3. If an ingress annotation was lost, reapply it out of band, for example:
+   ```bash
+   kubectl --context sparked-smile -n smile annotate ingress smilecdr-scdr \
+     nginx.ingress.kubernetes.io/proxy-body-size=16m --overwrite
+   ```
+
+## Notes
+
+- Terraform authenticates to EKS via `module.smile_cdr_dependencies.eks_cluster.*`, so the
+  repo's kubectl-context hook warning is a false alarm for terraform runs.
+- Provider constraints are driven by the module (`v9.0.2`): aws `>= 6.28.0`, helm `>= 3.1.1`,
+  kubernetes `>= 3.0.1`. If you bump the module, re-run `terraform init -upgrade` and update
+  `provider.tf` to match `.terraform/modules/.../versions.tf`.
+- The fork-safe `Validate Terraform` CI job runs `terraform fmt`/`validate` (no backend, no
+  credentials) on pull requests, so syntax and formatting are checked before you plan locally.


### PR DESCRIPTION
Now that terraform plan/apply is disabled in CI and applied locally, consolidate the deploy procedure into one authoritative runbook.

## Changes
- **New `docs/terraform-local-deploy.md`**: prerequisites (terraform 1.15.6, AWS SSO creds, the gitignored `backend.hcl`/`terraform.tfvars`, kubectl `--context sparked-smile`), one-time setup, safety snapshot, `init`/`plan`, plan-review bar (zero destroys, no Aurora downgrade, no KMS/secret replacement), `apply`, verification (node `metadata`, 16 MiB ingress body-size probe, auth flows), and rollback.
- **README**: Local Development, CI/CD, and Documentation sections now point at the runbook.
- **`docs/ci-deploy-enablement.md`**: marked superseded (it described moving apply into CI, which was reversed when the repo went public); retained for history.

Docs only. The drift/upgrade recovery procedure stays in `terraform/REMEDIATION.md`, which the runbook links to.