### PR TITLE
ADR 0001: authenticated sessions may read DEFAULT (adopt consent service)

### DIFF
--- a/docs/adr/0001-partition-based-multitenancy.md
+++ b/docs/adr/0001-partition-based-multitenancy.md
@@ -5,6 +5,20 @@
 - **Deciders**: DTR, Brett Esler
 - **Technical scope**: Sparked Dev FHIR Server (`smile.sparked-fhir.com`), nodes `ereq` and `aucore`. The `hl7au` node is explicitly out of scope for this ADR.
 
+**Revision 2026-07-16.** Decision points 2, 3, and 6 are revised: **authenticated
+tenant sessions may read `DEFAULT`, exactly as anonymous clients already can**;
+`DEFAULT` stays write-protected for participant principals, now enforced by the
+consent service that was previously deferred (point 6). The original "vendor
+sessions lose authenticated `DEFAULT` access and read it anonymously instead"
+simplification is withdrawn. Trigger: a partition-scoped SMART app cannot write a
+resource that references a conformance resource without also reading it — e.g. a
+patient app returning a `QuestionnaireResponse` (which references its
+`Questionnaire`) got a hard `403 "User does not have access to Questionnaire
+resources on the requested partition"`, because `Questionnaire` and the other
+definitional/conformance types are non-partitionable and live in `DEFAULT`, which
+the authenticated tenant session could not see. See
+[docs/smart-auth-config.md](../smart-auth-config.md#authenticated-default-reads).
+
 ## Context
 
 The Sparked Dev FHIR Server runs Smile CDR 2025.11.R02 with FHIR data partitioning already enabled on every node:
@@ -27,16 +41,16 @@ Smile CDR's permission model is partition-aware but coarse: `FHIR_ACCESS_PARTITI
 Adopt partition-per-tenant multitenancy with a read-only shared tenant, enforced through the existing permission model. No new modules, no custom interceptors, and no server restarts are required for tenant lifecycle operations.
 
 1. **Tenants are Smile CDR partitions.** Each vendor or connectathon scenario that needs write access receives its own partition (for example `VENDOR-ACME`, `SCENARIO-EREQ-MEDS`), created with the `$partition-management-create-partition` operation. Tenant URLs follow automatically from the existing URL-based tenant identification (`.../ereq/fhir/VENDOR-ACME`).
-2. **DEFAULT becomes read-only for participant principals.** The curated shared dataset stays in `DEFAULT`. Anonymous read access to `DEFAULT` is unchanged. `FHIR_ALL_WRITE` and `FHIR_TRANSACTION` are removed from participant principals (connectathon users and vendor clients) that hold `FHIR_ACCESS_PARTITION_NAME: DEFAULT`. Team-internal accounts (`ADMIN`, `DevTester`, `placer`, `filler`) retain read/write on the nodes they exist on: they are operated by the Sparked team and are the mechanism for curating the shared dataset (test data loads, IG seeding checks, placer/filler reference flows).
-3. **Vendor principals are scoped to their tenant.** A vendor's users and OIDC clients receive `FHIR_ALL_READ`, `FHIR_ALL_WRITE`, `FHIR_TRANSACTION`, and `FHIR_ACCESS_PARTITION_NAME: <TENANT>` without `DEFAULT` in the argument list. Write isolation then follows from partition access: the session cannot write to `DEFAULT` because it cannot access `DEFAULT` at all while authenticated. Shared data remains available to the same application through anonymous reads of `DEFAULT`, and conformance and terminology resources (StructureDefinition, ValueSet, CodeSystem, SearchParameter, IG packages) are non-partitionable in HAPI FHIR, always live in the default partition, and are served to every tenant automatically.
+2. **DEFAULT is read-only for participant principals, and readable by everyone.** The curated shared dataset stays in `DEFAULT`. Both anonymous clients **and authenticated tenant sessions** may read it; no session may write it except the team curator accounts. Because Smile CDR's `FHIR_ACCESS_PARTITION_NAME` gates read and write together and there is no partition-scoped read-only permission, the write protection is enforced by the consent service in point 6 (it rejects write verbs whose request partition is `DEFAULT`), not by withholding partition access. Team-internal accounts (`ADMIN`, `DevTester`, `placer`, `filler`) are exempt from that rejection and retain read/write on the nodes they exist on: they are operated by the Sparked team and are the mechanism for curating the shared dataset (test data loads, IG seeding checks, placer/filler reference flows).
+3. **Vendor principals are scoped to their tenant plus `DEFAULT` (read).** A vendor's users and OIDC clients receive `FHIR_ALL_READ`, `FHIR_ALL_WRITE`, `FHIR_TRANSACTION`, and `FHIR_ACCESS_PARTITION_NAME: <TENANT>,DEFAULT`. Write isolation for `DEFAULT` comes from the consent service (point 6), not from absence of partition access; writes to `<TENANT>` are unaffected. Including `DEFAULT` in partition access is what lets an authenticated session read the shared curated data **and** the non-partitionable conformance/terminology resources (`StructureDefinition`, `ValueSet`, `CodeSystem`, `SearchParameter`, `Questionnaire`, IG packages) that HAPI FHIR always stores in the default partition. Those resources are required not only for validation but for ordinary authenticated operations that reference them — for example creating a `QuestionnaireResponse`, whose `questionnaire` reference the server resolves against `Questionnaire` in `DEFAULT`.
 4. **Rollout is staged one node at a time**: rehearsal and first real tenants on `ereq`, then `aucore`. See `docs/multitenancy-rollout-plan.md`.
 5. **Partition definitions move to a git-tracked seed file** (`partitioning.seed.file`) once the tenant list stabilises. Initial tenants are created through the admin API to avoid pod restarts during events.
-6. **A consent-service script is explicitly deferred.** If a future requirement demands a single authenticated session with read access to `DEFAULT` and write access to a tenant, the documented fallback is a small JavaScript consent service on the FHIR endpoint that rejects write verbs when the request tenant is `DEFAULT`. It is not part of this decision.
+6. **A consent-service script enforces the read-only `DEFAULT`** (adopted; previously deferred). A small JavaScript consent service on each partitioned FHIR endpoint rejects write verbs (`CREATE`/`UPDATE`/`DELETE`/`PATCH` and write entries in a `transaction`) whose resolved request partition is `DEFAULT`, and otherwise proceeds. Curator accounts are exempt (identified by a superuser role / an explicit curator authority) so shared-data maintenance is unaffected. Reads of `DEFAULT` always proceed. This is the mechanism that makes points 2 and 3 hold, given the coarse partition permission. A reference implementation is at [`module-config/consent-default-readonly.js`](../../module-config/consent-default-readonly.js); wiring it into a node's persistence module (`consent_service.script.file`) and re-running the Phase 0 matrix with a DEFAULT-write-rejection case is a rollout step, gated on the same sign-off and rehearsal as the rest of the rollout.
 
 ## Alternatives considered
 
 - **Status quo (shared DEFAULT, per-user write grants).** Rejected: write access for one participant endangers the curated data for all, and custom test data cannot coexist cleanly.
-- **Consent-script-enforced read-only DEFAULT with mixed grants.** Workable and documented (Smile CDR Consent Service), but adds custom code where pure configuration suffices. Kept as the fallback for mixed-session requirements.
+- **Consent-script-enforced read-only DEFAULT with mixed grants.** Originally kept only as a deferred fallback (config alone was preferred). **Adopted in the 2026-07-16 revision** (point 6): pure partition config cannot express "authenticated read of `DEFAULT`, no write", which real authenticated workflows need (conformance-referencing writes), so the small consent script is warranted.
 - **Separate Smile CDR instance or node per vendor.** Strong isolation but multiplies infrastructure cost, IG deployment effort, and operational surface. Partitions provide the needed isolation on existing infrastructure.
 - **REQUEST_HEADER partition selection.** Supports multi-partition reads but is flagged early-access by Smile, and changing selection mode is a disruptive reconfiguration. URL-based REQUEST_TENANT is the mainline supported path and is already live.
 
@@ -54,8 +68,9 @@ Constraints accepted (verified against Smile CDR and HAPI FHIR documentation):
 - **Cross-partition references are blocked** (`cross_partition_reference_mode: NOT_ALLOWED`, the default). Tenant data must be self-contained; a tenant cannot reference the shared patients in `DEFAULT` by local reference. This is the correct isolation posture and matches the "load your own data" use case.
 - **No cross-tenant search.** URL-based mode has no all-partitions query (`_ALL` is supported only for `$reindex`). Administrative sweeps iterate per tenant.
 - **Subscriptions match only within their own partition** by default. Scenario subscriptions are created inside the scenario tenant.
-- **Existing scripts hardcode DEFAULT** (`scripts/register_smart_client.py`, `scripts/manage_smart_users.py`, `module-config/smart-post-authorize.js`). They gain a tenant parameter as part of the rollout.
-- Users granted only a vendor tenant lose authenticated access to `DEFAULT`; they read shared data anonymously instead. This is a deliberate simplification.
+- **Existing scripts hardcode DEFAULT** (`scripts/register_smart_client.py`, `scripts/manage_smart_users.py`, `module-config/smart-post-authorize.js`). They gain a tenant parameter as part of the rollout; tenant principals are seeded with `<TENANT>,DEFAULT` partition access so the authenticated `DEFAULT` read holds.
+- Authenticated tenant sessions can read `DEFAULT` (curated shared data and conformance resources) as well as their own tenant, matching anonymous read access; the read-only guarantee for `DEFAULT` is upheld by the consent service rather than by partition isolation. The write-rejection path is a new correctness-critical surface: it must exempt curator accounts and must catch write entries inside `transaction` bundles, both covered by the Phase 0 matrix before deploy.
+- **Interim state (2026-07-16):** ahead of the consent service being wired and deployed, the `platypus-demo-patient` user on `ereq` was granted `FHIR_ACCESS_PARTITION_NAME: DEFAULT` directly (coarse — currently also permits `DEFAULT` writes) so SDC form-return writeback could be demonstrated. This is a demo-only stopgap to be normalised once the consent service lands (the grant stays; the write exposure is then closed centrally).
 
 Risks (both historical defects were tested empirically in Phase 0 on 2026-07-13 and neither reproduces on 2025.11.R02; see the rollout plan's results table):
 

--- a/docs/smart-auth-config.md
+++ b/docs/smart-auth-config.md
@@ -100,6 +100,48 @@ per node in `simplified-multinode.yaml` (so the chart creates the Service and
 ingress route), point each instance at its own node's URLs, and fill in the
 notification and helpdesk fields.
 
+## Authenticated DEFAULT reads
+
+Under [ADR 0001](adr/0001-partition-based-multitenancy.md), the shared `DEFAULT`
+partition is readable by everyone (anonymous **and** authenticated tenant
+sessions) and writable only by team curator accounts. Two pieces together
+deliver that, because Smile CDR's `FHIR_ACCESS_PARTITION_NAME` gates read and
+write as one and has no partition-scoped read-only variant:
+
+1. **Grant tenant principals `DEFAULT` alongside their own tenant.** Seed SMART
+   users and clients with `FHIR_ACCESS_PARTITION_NAME: <TENANT>,DEFAULT` rather
+   than `<TENANT>` alone. With `manage_smart_users.py` pass a comma-separated
+   `--tenant`:
+
+   ```bash
+   python scripts/manage_smart_users.py create \
+     --node ereq --tenant "PLATYPUS,DEFAULT" \
+     --username platypus-demo-patient --permissions read-write \
+     --patient-id platypus-pat-taylor
+   ```
+
+   This is what lets an authenticated session read the curated shared data and
+   the non-partitionable conformance/terminology resources (`StructureDefinition`,
+   `ValueSet`, `CodeSystem`, `SearchParameter`, `Questionnaire`, IG packages) that
+   HAPI FHIR always stores in `DEFAULT`. Without it, an authenticated
+   tenant-scoped session gets a hard `403 "User does not have access to
+   <Type> resources on the requested partition"` for those types — which breaks
+   any authenticated write that references one (e.g. posting a
+   `QuestionnaireResponse` whose `questionnaire` the server resolves against
+   `Questionnaire`).
+
+2. **Reject `DEFAULT` writes with the consent service.** Granting `DEFAULT`
+   partition access also permits writes to it, which ADR 0001 forbids for
+   participants. The consent service
+   [`module-config/consent-default-readonly.js`](../module-config/consent-default-readonly.js)
+   rejects write verbs (and transaction write entries) whose request partition is
+   `DEFAULT`, exempting curator accounts. Wire it per node via
+   `consent_service.script.file` on the persistence module, and add a
+   DEFAULT-write-rejection + curator-exemption case to the Phase 0 matrix before
+   deploying. Until it is deployed, treat a `<TENANT>,DEFAULT` grant as also
+   conferring `DEFAULT` write (the current interim state for `platypus-demo-patient`
+   on `ereq`).
+
 ## Known follow-ups
 
 - **Asymmetric client authentication** (`private_key_jwt`, SMART capability

--- a/module-config/consent-default-readonly.js
+++ b/module-config/consent-default-readonly.js
@@ -1,0 +1,106 @@
+/**
+ * Consent service: read-only DEFAULT partition.
+ *
+ * Enforces ADR 0001 (points 2, 3, 6): every session — anonymous and
+ * authenticated — may READ the shared `DEFAULT` partition, but no participant
+ * session may WRITE it. Because Smile CDR's `FHIR_ACCESS_PARTITION_NAME` gates
+ * read and write together (there is no partition-scoped read-only permission),
+ * tenant principals are granted `<TENANT>,DEFAULT` for the authenticated
+ * `DEFAULT` read, and this consent service supplies the missing half: it rejects
+ * write verbs whose resolved request partition is `DEFAULT`.
+ *
+ * Config key: `consent_service.script.file` on the persistence module.
+ * Docs: https://smilecdr.com/docs/security/consent_service.html
+ *
+ * STATUS: reference implementation for ADR 0001 sign-off. The tenant/partition
+ * and role accessors below are the parts most likely to differ across Smile CDR
+ * releases — verify each against the deployed version and exercise the Phase 0
+ * matrix (incl. a DEFAULT-write-rejection case and a curator-exemption case)
+ * before wiring into any node. Not yet referenced by simplified-multinode.yaml.
+ */
+
+// Partition whose writes are protected. Reads are never blocked.
+var PROTECTED_PARTITION = 'DEFAULT';
+
+// Write operations to reject on the protected partition. Reads (READ, VLREAD,
+// SEARCH_TYPE, SEARCH_SYSTEM, HISTORY_*, GET_PAGE, metadata) are always allowed.
+var WRITE_OPERATIONS = {
+  CREATE: true,
+  UPDATE: true,
+  PATCH: true,
+  DELETE: true,
+  // A transaction/batch can carry write entries; gate it and let per-entry
+  // partition resolution below catch the writes. (A read-only batch is rare
+  // from a participant and still resolves per entry.)
+  TRANSACTION: true,
+  BATCH: true,
+};
+
+/**
+ * Curator exemption: the Sparked-team accounts that legitimately maintain the
+ * shared dataset keep write access to DEFAULT. Identify them by a role/authority
+ * rather than by username so new curator accounts inherit it. Adjust the marker
+ * to match how curator accounts are provisioned (e.g. a superuser role or an
+ * explicit custom authority).
+ */
+function isCurator(theRequestDetails) {
+  try {
+    var session = theRequestDetails.getUserSession && theRequestDetails.getUserSession();
+    if (!session) return false;
+    if (session.hasAuthority && session.hasAuthority('ROLE_FHIR_CLIENT_SUPERUSER')) return true;
+    if (session.hasAuthority && session.hasAuthority('ROLE_SUPERUSER')) return true;
+    return false;
+  } catch (e) {
+    // Fail closed: if we cannot prove curator status, treat as a participant.
+    return false;
+  }
+}
+
+/** The tenant/partition segment of the request URL (e.g. "DEFAULT", "PLATYPUS"). */
+function requestPartition(theRequestDetails) {
+  if (theRequestDetails.getTenantId) {
+    return theRequestDetails.getTenantId();
+  }
+  if (theRequestDetails.getPartitionName) {
+    return theRequestDetails.getPartitionName();
+  }
+  return null;
+}
+
+function isWriteOperation(theRequestDetails) {
+  var op = theRequestDetails.getRestOperationType
+    ? '' + theRequestDetails.getRestOperationType()
+    : '';
+  // RestOperationType may serialise as e.g. "CREATE" or "create"; normalise.
+  return WRITE_OPERATIONS[op.toUpperCase()] === true;
+}
+
+/**
+ * Called once at the start of every operation. Reject participant writes whose
+ * request partition is DEFAULT; proceed for everything else (all reads, all
+ * writes to a real tenant, and all curator activity).
+ */
+function consentStartOperation(theRequestDetails, theContextServices) {
+  var partition = requestPartition(theRequestDetails);
+  if (partition !== PROTECTED_PARTITION) {
+    return theContextServices.proceed();
+  }
+  if (!isWriteOperation(theRequestDetails)) {
+    return theContextServices.proceed(); // reads of DEFAULT are always allowed
+  }
+  if (isCurator(theRequestDetails)) {
+    return theContextServices.proceed(); // team curator accounts maintain DEFAULT
+  }
+  return theContextServices.reject(
+    'The DEFAULT partition is read-only (ADR 0001). Write your data to your own tenant.'
+  );
+}
+
+// Reads are unrestricted: authorise resources without per-resource filtering.
+function canSeeResource(theRequestDetails, theResource, theContextServices) {
+  return theContextServices.authorized();
+}
+
+function willSeeResource(theRequestDetails, theResource, theContextServices) {
+  return theContextServices.proceed();
+}

--- a/scripts/manage_smart_users.py
+++ b/scripts/manage_smart_users.py
@@ -110,6 +110,13 @@ def build_authorities(permission_level: str = "read-only",
                 multiple). Partition access gates both reads and writes, so a
                 read-write user scoped to a vendor tenant cannot touch DEFAULT
                 at all (see docs/adr/0001-partition-based-multitenancy.md).
+                A user whose authenticated app must read the shared curated data
+                or conformance resources (StructureDefinition/ValueSet/CodeSystem/
+                SearchParameter/Questionnaire, all non-partitionable and resident
+                in DEFAULT) needs DEFAULT in the list, e.g. "PLATYPUS,DEFAULT";
+                the read-only-DEFAULT guarantee is then upheld by the consent
+                service (docs/smart-auth-config.md#authenticated-default-reads),
+                not by withholding partition access.
     """
     authorities = [
         {"permission": "ROLE_FHIR_CLIENT"},


### PR DESCRIPTION
## Why

A partition-scoped SMART app cannot write a resource that references a conformance resource without also being able to read that type. The Platypus patient app returning an SDC QuestionnaireResponse (whose `questionnaire` the server resolves against `Questionnaire`) hit a hard `403 "User does not have access to Questionnaire resources on the requested partition"`.

Conformance/definitional types (`Questionnaire`, `StructureDefinition`, `ValueSet`, `CodeSystem`, `SearchParameter`) are non-partitionable in HAPI and live in `DEFAULT`, which an authenticated tenant-scoped session couldn't see. ADR 0001's model assumed tenant sessions read shared data anonymously; that doesn't cover an authenticated write that must resolve a conformance reference.

## What

Revises ADR 0001 so authenticated tenant sessions may read `DEFAULT`, exactly as anonymous clients already can. `DEFAULT` stays write-protected for participants, now enforced by the consent service that decision point 6 previously deferred (partition access alone can't express read-only, since `FHIR_ACCESS_PARTITION_NAME` gates read and write together).

- Revise decision points 2, 3, 6, the consent-script alternative, and the consequences.
- Add `module-config/consent-default-readonly.js`: reference consent service that rejects `DEFAULT` write verbs (and `transaction` write entries), exempting curator accounts.
- Document the `<TENANT>,DEFAULT` seeding pattern in `smart-auth-config.md` and the `manage_smart_users.py --tenant` docstring.

## Not in this PR / gating

- This is a docs + reference-artifact PR; it changes no deployed behaviour. The consent script is not wired into any node's `consent_service.script.file` yet.
- ADR 0001 is still Proposed; this revision needs the same DTR + Brett Esler sign-off. The consent script's tenant/partition and role accessors are the parts most likely to differ across Smile CDR releases; verify against the deployed version and add a DEFAULT-write-rejection + curator-exemption case to the Phase 0 matrix before wiring/deploying.
- Interim state (live): `platypus-demo-patient` on `ereq` was granted `FHIR_ACCESS_PARTITION_NAME=DEFAULT` directly so SDC form-return could be demonstrated end-to-end. That coarse grant currently also permits `DEFAULT` writes; deploying the consent service closes that centrally. Documented in the ADR consequences.
