### PR TITLE
Align aucore seed whitelist with live: add CarePlan/Goal/CareTeam

### DIFF
--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -27,7 +27,11 @@ cdrNodes:
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
           package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-6.1.1-draft.json classpath:/config_seeding/package-au-patient-summary-1.0.0.json classpath:/config_seeding/package-aucore-2.1.0-draft.json classpath:/config_seeding/package-international-patient-summary-2.0.1.json"
-          resource_types.supported.whitelist: "MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,Questionnaire,StructureMap,AllergyIntolerance,Condition,Encounter,Immunization,Location,Observation,Organization,Patient,Practitioner,PractitionerRole,Procedure,Medication,MedicationRequest,Coverage,Specimen,RelatedPerson,HealthcareService,QuestionnaireResponse"
+          # Pulled from the live aucore node (2026-07-20) to eliminate seed drift.
+          # Adds CarePlan/Goal/CareTeam (patient Care Plan viewer support) and the
+          # DiagnosticReport/DocumentReference/MedicationDispense/Endpoint/Bundle
+          # types that were already enabled live but never written back to the seed.
+          resource_types.supported.whitelist: "CarePlan,Goal,CareTeam,Endpoint,DocumentReference,MedicationDispense,DiagnosticReport,Bundle,MedicationStatement,CommunicationRequest,Task,Consent,ServiceRequest,Device,Composition,StructureDefinition,SearchParameter,Questionnaire,StructureMap,AllergyIntolerance,Condition,Encounter,Immunization,Location,Observation,Organization,Patient,Practitioner,PractitionerRole,Procedure,Medication,MedicationRequest,Coverage,Specimen,RelatedPerson,HealthcareService,QuestionnaireResponse"
           metadata.resource_counts.enabled: false
           validator.local_reference_policy: "NOT_VALIDATED"
           validator.unknown_codesystem_validation_policy: "GENERATE_WARNING"


### PR DESCRIPTION
## What

Pulls the **live aucore** resource-type whitelist
(`persistence.resource_types.supported.whitelist`) back into the seed
(`module-config/simplified-multinode.yaml`) so a fresh deploy / config reset
reproduces what is actually running. Scoped to the `aucore` node.

The seed listed 29 types; the live node serves 37. This PR sets the seed to the
live value:
- **`CarePlan`, `Goal`, `CareTeam`** — added to support the patient-facing **Care
  Plan viewer** (the Platypus consumer app reads a `CarePlan` and links its
  addressed `Condition`s, `activity` records, `Goal`s and `CareTeam` to the
  patient's own held records). AU Core does not profile these three, which is why
  they were never in the seed; they are read/stored as base R4.
- **`DiagnosticReport`, `DocumentReference`, `MedicationDispense`, `Endpoint`,
  `Bundle`** — already enabled on the live node but never written back to the seed.
  Captured here so the seed stops under-declaring reality.

## Why now
The Platypus Care Plan viewer needs these three types on aucore; the live whitelist
was extended on the node, and this PR persists that (and the pre-existing drift) so
it survives a redeploy.

## Notes for reviewers
- **DB-backed config** (`config.database: true`): this updates the **first-boot
  seed only** and does not itself mutate the running node.
- **Scope**: `aucore` only. `hl7au`'s seed carries the same stale 29-type list; left
  as-is here (out of scope for the Care Plan work).
- Values were read from the live node's admin JSON module-config API before writing.
- No auth/security changes: partition access is unchanged (named partitions require
  an authenticated user of that partition; DEFAULT stays world-readable).