### PR TITLE
Decommission the ereq and hl7au nodes

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-ig-release-request.yml
@@ -95,19 +95,17 @@ body:
       description: |
         Which SmileCDR nodes should this IG package be deployed to?
 
-        The `aucore` and `ereq` nodes make up the **Sparked Dev FHIR Server** on
+        The `aucore` node is the **Sparked Dev FHIR Server** on
         `smile.sparked-fhir.com`. This is not the HL7 AU reference server at `fhir.hl7.org.au`,
         which is a separate system (see the repository Governance notes).
 
         **Node Descriptions:**
         - **aucore**: AU Core node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/aucore`)
-        - **ereq**: eRequesting node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/ereq`)
 
-        **Tip**: Most Australian IGs should be requested for `aucore`. eRequesting-specific IGs should also include `ereq`.
+        The `ereq` and `hl7au` nodes were decommissioned on 2026-08-02. AU eRequesting is no
+        longer run under Sparked, so eRequesting IG releases are not deployed here.
       options:
         - label: aucore (Sparked dev AU Core node)
-          required: false
-        - label: ereq (Sparked dev eRequesting node)
           required: false
   - type: checkboxes
     id: deployment-options

--- a/.github/ISSUE_TEMPLATE/03-operational-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-operational-request.yml
@@ -113,7 +113,6 @@ body:
       description: Which node should the test data load into? Defaults to aucore if left blank.
       options:
         - aucore
-        - ereq
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
+++ b/.github/ISSUE_TEMPLATE/05-smart-app-registration.yml
@@ -54,14 +54,13 @@ body:
     attributes:
       label: Target Nodes
       description: |
-        Select which FHIR server node(s) to register the client on. Each node has its own client registry and auth endpoints.
-        The `aucore` and `ereq` nodes are the Sparked Dev FHIR Server (`smile.sparked-fhir.com`), not the HL7 AU reference server at `fhir.hl7.org.au`.
+        Select which FHIR server node to register the client on.
+        The `aucore` node is the Sparked Dev FHIR Server (`smile.sparked-fhir.com`), not the HL7 AU reference server at `fhir.hl7.org.au`.
         - **aucore**: AU Core node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/aucore`)
-        - **ereq**: eRequesting node of the Sparked Dev FHIR Server (`smile.sparked-fhir.com/ereq`)
+
+        The `ereq` and `hl7au` nodes were decommissioned on 2026-08-02.
       options:
         - label: "aucore"
-          required: false
-        - label: "ereq"
           required: false
 
   - type: textarea
@@ -110,8 +109,8 @@ body:
       description: |
         The tenant (data partition) your client should be scoped to.
         Leave blank for the shared `DEFAULT` tenant, which is **read-only** for participant clients.
-        If you need write access (loading your own test data, eRequesting placer/filler flows),
-        request a vendor or scenario tenant here, e.g. `VENDOR-ACME` or `SCENARIO-EREQ-MEDS`.
+        If you need write access (loading your own test data), request a vendor or scenario
+        tenant here, e.g. `VENDOR-ACME`.
         Your FHIR base URL becomes `https://smile.sparked-fhir.com/<node>/fhir/<TENANT>`.
         If the tenant does not exist yet, we create it as part of this request.
       placeholder: "VENDOR-ACME"

--- a/.github/ISSUE_TEMPLATE/06-general-request.yml
+++ b/.github/ISSUE_TEMPLATE/06-general-request.yml
@@ -45,7 +45,7 @@ body:
       description: |
         Full description of the request.
         For a **bug report**, please include: steps to reproduce, expected vs actual behaviour,
-        and the affected node/environment (e.g. aucore, ereq, tx.dev).
+        and the affected node/environment (e.g. aucore, tx.dev).
       placeholder: "Describe what you need, or what went wrong and how to reproduce it."
     validations:
       required: true

--- a/.github/workflows/clear-test-data.yml
+++ b/.github/workflows/clear-test-data.yml
@@ -18,7 +18,6 @@ on:
         default: "aucore"
         options:
           - aucore
-          - ereq
           - custom
       custom_fhir_url:
         description: "Custom FHIR server URL (only when target_node=custom)"
@@ -167,7 +166,6 @@ jobs:
           # Resolve FHIR URL from node name
           case "$TARGET_NODE" in
             aucore) FHIR_URL="https://smile.sparked-fhir.com/aucore/fhir/DEFAULT" ;;
-            ereq)   FHIR_URL="https://smile.sparked-fhir.com/ereq/fhir/DEFAULT" ;;
             custom) FHIR_URL="$CUSTOM_FHIR_URL" ;;
             *)      echo "::error::Unknown target node: $TARGET_NODE"; exit 1 ;;
           esac

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -102,8 +102,10 @@ jobs:
               const lines = targetNodesSection.split('\n');
               for (const line of lines) {
                 if (line.includes('[x]') || line.includes('[X]')) {
+                  // aucore is the only node since the ereq/hl7au decommission
+                  // (2026-08-02). Issues opened before then may still tick ereq;
+                  // it is ignored rather than dispatched at a node that is gone.
                   if (line.includes('aucore')) selectedNodes.push('aucore');
-                  if (line.includes('ereq')) selectedNodes.push('ereq');
                 }
               }
             }
@@ -942,11 +944,11 @@ jobs:
             // free-text node mention, then default (aucore).
             let targetNode = '';
             const targetNodeField = section('Target Node').toLowerCase();
-            if (targetNodeField.includes('ereq')) targetNode = 'ereq';
-            else if (targetNodeField.includes('aucore')) targetNode = 'aucore';
+            // aucore only since the ereq/hl7au decommission (2026-08-02).
+            if (targetNodeField.includes('aucore')) targetNode = 'aucore';
             // Legacy free-text "node: <name>" mention, only if the explicit field was absent.
             if (!section('Target Node')) {
-              const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore|ereq)[`"]?/i);
+              const nodeMatch = issueBody.match(/(?:target[_ ]?node|node)[:\s]*[`"]?(aucore)[`"]?/i);
               if (nodeMatch) targetNode = nodeMatch[1].toLowerCase();
             }
             // A custom FHIR URL overrides node selection.
@@ -1067,8 +1069,10 @@ jobs:
               const lines = targetNodesSection.split('\n');
               for (const line of lines) {
                 if (line.includes('[x]') || line.includes('[X]')) {
+                  // aucore is the only node since the ereq/hl7au decommission
+                  // (2026-08-02). Issues opened before then may still tick ereq;
+                  // it is ignored rather than dispatched at a node that is gone.
                   if (line.includes('aucore')) selectedNodes.push('aucore');
-                  if (line.includes('ereq')) selectedNodes.push('ereq');
                 }
               }
             }

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -176,8 +176,10 @@ jobs:
               const lines = targetNodesSection.split('\n');
               for (const line of lines) {
                 if (line.includes('[x]') || line.includes('[X]')) {
+                  // aucore is the only node since the ereq/hl7au decommission
+                  // (2026-08-02). Issues opened before then may still tick ereq;
+                  // it is ignored rather than dispatched at a node that is gone.
                   if (line.includes('aucore')) selectedNodes.push('aucore');
-                  if (line.includes('ereq')) selectedNodes.push('ereq');
                 }
               }
             }

--- a/.github/workflows/load-test-data.yml
+++ b/.github/workflows/load-test-data.yml
@@ -18,7 +18,6 @@ on:
         default: "aucore"
         options:
           - aucore
-          - ereq
           - custom
       custom_fhir_url:
         description: "Custom FHIR server URL (only when target_node=custom)"
@@ -171,7 +170,6 @@ jobs:
           # Resolve FHIR URL from node name
           case "$TARGET_NODE" in
             aucore) FHIR_URL="https://smile.sparked-fhir.com/aucore/fhir/DEFAULT" ;;
-            ereq)   FHIR_URL="https://smile.sparked-fhir.com/ereq/fhir/DEFAULT" ;;
             custom) FHIR_URL="$CUSTOM_FHIR_URL" ;;
             *)      echo "::error::Unknown target node: $TARGET_NODE"; exit 1 ;;
           esac

--- a/.github/workflows/manage-test-data.yml
+++ b/.github/workflows/manage-test-data.yml
@@ -9,8 +9,6 @@ on:
         type: choice
         options:
           - clear-and-load-aucore
-          - clear-and-load-ereq
-          - clear-and-load-aucore-and-ereq
           - clear-and-expunge
       target_node:
         description: "Target node (only for clear-and-expunge operation)"
@@ -19,7 +17,6 @@ on:
         default: "aucore"
         options:
           - aucore
-          - ereq
       dry_run:
         description: "Dry run (preview without making changes)"
         required: false
@@ -41,9 +38,7 @@ permissions:
 jobs:
   clear-aucore:
     name: Clear aucore
-    if: >-
-      inputs.operation == 'clear-and-load-aucore' ||
-      inputs.operation == 'clear-and-load-aucore-and-ereq'
+    if: inputs.operation == 'clear-and-load-aucore'
     uses: ./.github/workflows/clear-test-data.yml
     with:
       delete_mode: wipe-all
@@ -57,9 +52,7 @@ jobs:
   load-aucore:
     name: Load aucore
     needs: clear-aucore
-    if: >-
-      inputs.operation == 'clear-and-load-aucore' ||
-      inputs.operation == 'clear-and-load-aucore-and-ereq'
+    if: inputs.operation == 'clear-and-load-aucore'
     uses: ./.github/workflows/load-test-data.yml
     with:
       upload_method: direct
@@ -70,39 +63,8 @@ jobs:
     secrets:
       CSIRO_FHIR_AUTH_64: ${{ secrets.CSIRO_FHIR_AUTH_64 }}
 
-  # ============================================================================
-  # Clear and Load eRequesting
-  # ============================================================================
-  clear-ereq:
-    name: Clear ereq
-    if: >-
-      inputs.operation == 'clear-and-load-ereq' ||
-      inputs.operation == 'clear-and-load-aucore-and-ereq'
-    uses: ./.github/workflows/clear-test-data.yml
-    with:
-      delete_mode: wipe-all
-      target_node: ereq
-      expunge: true
-      dry_run: ${{ inputs.dry_run }}
-      issue_number: ${{ inputs.issue_number && fromJSON(inputs.issue_number) || 0 }}
-    secrets:
-      CSIRO_FHIR_AUTH_64: ${{ secrets.CSIRO_FHIR_AUTH_64 }}
-
-  load-ereq:
-    name: Load ereq
-    needs: clear-ereq
-    if: >-
-      inputs.operation == 'clear-and-load-ereq' ||
-      inputs.operation == 'clear-and-load-aucore-and-ereq'
-    uses: ./.github/workflows/load-test-data.yml
-    with:
-      upload_method: direct
-      target_node: ereq
-      dry_run: ${{ inputs.dry_run }}
-      continue_on_error: true
-      issue_number: ${{ inputs.issue_number && fromJSON(inputs.issue_number) || 0 }}
-    secrets:
-      CSIRO_FHIR_AUTH_64: ${{ secrets.CSIRO_FHIR_AUTH_64 }}
+  # The ereq clear/load jobs were removed with the ereq node decommission
+  # (2026-08-02, issue #85). aucore is the only node.
 
   # ============================================================================
   # Clear and Expunge (any node)

--- a/.github/workflows/reload-ig-config.yml
+++ b/.github/workflows/reload-ig-config.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: "https://smile.sparked-fhir.com"
       nodes:
-        description: "Comma-separated list of node names to update (e.g., 'aucore,ereq' or 'all' for all nodes)"
+        description: "Comma-separated list of node names to update (e.g., 'aucore' or 'all' for all nodes)"
         required: true
         default: "aucore"
       package_source:

--- a/docs/SERVICE-CATALOGUE.md
+++ b/docs/SERVICE-CATALOGUE.md
@@ -255,14 +255,18 @@ dev environments from HL7-hosted reference environments.
 
 | Environment | Host | Scrutiny |
 |-------------|------|----------|
-| `aucore`, `ereq` nodes | `smile.sparked-fhir.com` (CSIRO) | Normal workflow |
+| `aucore` node | `smile.sparked-fhir.com` (CSIRO) | Normal workflow |
 | `tx.dev` terminology server | `synd.ontoserver.csiro.au` (CSIRO) | Normal workflow |
 | `tx.hl7` terminology server | `synd.tx.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off |
 | `fhir.hl7.org.au` FHIR reference server | `fhir.hl7.org.au` (HL7) | Elevated: `needs:hl7-approval` + Brett Esler sign-off; not an automation target today |
 
-The `aucore` and `ereq` nodes make up the Sparked Dev FHIR Server on `smile.sparked-fhir.com`.
-It is not the production HL7 AU reference server at `fhir.hl7.org.au`, which is a separate
-system.
+The `aucore` node is the Sparked Dev FHIR Server on `smile.sparked-fhir.com`. It is not the
+production HL7 AU reference server at `fhir.hl7.org.au`, which is a separate system.
+
+The `ereq` and `hl7au` nodes were decommissioned on 2026-08-02 (issue #85): AU eRequesting is
+no longer run under Sparked and the agreed hosting period ran to end July 2026. Requests
+naming those nodes can no longer be actioned. The AU eRequesting IG package
+(`hl7.fhir.au.ereq`) is unaffected and is still published by the terminology servers.
 
 For any request that changes an HL7-hosted reference environment, a reviewer adds
 `needs:hl7-approval` and must not move the request to `approved` or `ready-for-automation`

--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -1,5 +1,30 @@
-## when deploying start with just aucore, then sequentially add hl7au, ereq otherwise potential configmap duplicate name issue can occur
-# ~1min 50sec to deploy hl7au with config
+# The Sparked Dev FHIR Server is a single node, aucore, as of 2026-08-02.
+#
+# ereq and hl7au are DECOMMISSIONED. This is stage 1 of 2: the nodes are disabled
+# so their pods stop, but their config blocks, their `db_users` entries in
+# terraform/main.tf and their databases are all left in place. That keeps the
+# decommission a one-line revert for as long as the data is still wanted.
+#
+#   ereq   the AU eRequesting project is no longer run under Sparked; the agreed
+#          hosting period ran to end July 2026 (issue #85, requested by @dt-r).
+#   hl7au  decommissioned alongside it on the environment owner's direction. Note
+#          this node is NOT the HL7 AU reference server at fhir.hl7.org.au, which
+#          is a separate system and is unaffected.
+#
+# The AU eRequesting IG package (hl7.fhir.au.ereq) is a different thing from the
+# ereq NODE and is unaffected: the terminology servers still publish it, so
+# nothing under terminology-servers/ changes.
+#
+# Stage 2, after the data is confirmed no longer needed: delete these two node
+# blocks, drop the `ereq` and `hl7au` entries from `db_users` in
+# terraform/main.tf (which drops the databases), and remove
+# module-config/packages/package-au-erequesting-1.0.0.json together with its
+# `helm_chart_mapped_files` entry and its values-common.yaml reference. Only ereq
+# seeded that package, so nothing else loses it.
+#
+# Deployment note (historical, applies whenever more than one node is enabled):
+# start with just aucore, then add nodes sequentially, otherwise a configmap
+# duplicate name issue can occur. hl7au took ~1min 50sec to deploy with config.
 cdrNodes:
   masterdev:
     enabled: false
@@ -98,7 +123,10 @@ cdrNodes:
           cors.enable: true
   hl7au:
     name: hl7au
-    enabled: true
+    # DECOMMISSIONED 2026-08-02 (stage 1 of 2). See the header note at the top of
+    # this file. The node config below is retained verbatim so the change is a
+    # one-line revert while the hl7au database still exists.
+    enabled: false
     # hl7au does not run the AUPS generator, but it already carried the 1.0.0 jar
     # under the previous global copyFiles. Keep it here so moving copyFiles per-node
     # does not change hl7au's pod spec (avoids an unnecessary restart).
@@ -167,7 +195,10 @@ cdrNodes:
           context_path: "/hl7au/fhirweb"
   ereq:
     name: ereq
-    enabled: true
+    # DECOMMISSIONED 2026-08-02 (stage 1 of 2), per issue #85. See the header note
+    # at the top of this file. The node config below is retained verbatim so the
+    # change is a one-line revert while the ereq database still exists.
+    enabled: false
     # ereq pins the older 0.1.0-alpha AU Patient Summary generator jar (aucore runs 1.0.0),
     # consumed by ig_support.ips.generation_strategy_class in the persistence config below.
     copyFiles:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,38 +49,6 @@ sparked-test-data-loader load \
   --auth-header "$FHIR_AUTH_HEADER"
 ```
 
-**Clear and reload eRequesting test data:**
-```bash
-sparked-test-data-loader clear \
-  --mode wipe-all \
-  --fhir-url https://smile.sparked-fhir.com/ereq/fhir/DEFAULT \
-  --auth-header "$FHIR_AUTH_HEADER" \
-  --expunge
-
-sparked-test-data-loader load \
-  --method direct \
-  --fhir-url https://smile.sparked-fhir.com/ereq/fhir/DEFAULT \
-  --data-dir /tmp/test-data/au-fhir-test-data-set \
-  --auth-header "$FHIR_AUTH_HEADER"
-```
-
-**Load to both AU Core + eRequesting nodes:**
-```bash
-# Load to aucore
-sparked-test-data-loader load \
-  --method direct \
-  --fhir-url https://smile.sparked-fhir.com/aucore/fhir/DEFAULT \
-  --data-dir /tmp/test-data/au-fhir-test-data-set \
-  --auth-header "$FHIR_AUTH_HEADER"
-
-# Load to ereq
-sparked-test-data-loader load \
-  --method direct \
-  --fhir-url https://smile.sparked-fhir.com/ereq/fhir/DEFAULT \
-  --data-dir /tmp/test-data/au-fhir-test-data-set \
-  --auth-header "$FHIR_AUTH_HEADER"
-```
-
 **Dry run (preview without changes):**
 ```bash
 sparked-test-data-loader load \
@@ -95,7 +63,7 @@ sparked-test-data-loader load \
 
 Use the **Manage Test Data** workflow for common operations:
 - **Actions** -> **Manage Test Data** -> **Run workflow**
-- Operations: `clear-and-load-aucore`, `clear-and-load-ereq`, `clear-and-load-aucore-and-ereq`, `clear-and-expunge`
+- Operations: `clear-and-load-aucore`, `clear-and-expunge`
 
 Or use the individual workflows directly:
 - **Load Test Data** (`load-test-data.yml`) - Load data to any node
@@ -187,7 +155,7 @@ python scripts/sync_smart_auth.py
 python scripts/sync_smart_auth.py --apply
 
 # Single node
-python scripts/sync_smart_auth.py --apply --node ereq
+python scripts/sync_smart_auth.py --apply --node aucore
 
 # Also archive the unused appSphere (app_gallery) module
 python scripts/sync_smart_auth.py --archive-app-gallery --apply
@@ -230,7 +198,7 @@ python sync_packages.py --nodes all --source config --dry-run
 python sync_packages.py --nodes aucore --source config
 
 # Update multiple specific nodes
-python sync_packages.py --nodes aucore,ereq --source config
+python sync_packages.py --nodes aucore --source config
 
 # Force reinstall all packages
 python sync_packages.py --nodes all --source config --force-reinstall

--- a/scripts/apply_ig_release.py
+++ b/scripts/apply_ig_release.py
@@ -28,7 +28,7 @@ Usage:
         --package-id hl7.fhir.au.core \
         --version 2.1.0-draft \
         --ig-name "AU Core" \
-        --nodes aucore,ereq \
+        --nodes aucore \
         --install-mode STORE_AND_INSTALL \
         --fetch-dependencies false \
         --package-url ""            # optional; omit/empty to resolve from registry

--- a/scripts/clear_test_data.py
+++ b/scripts/clear_test_data.py
@@ -12,18 +12,18 @@ Usage:
     # Targeted: delete only resources found in a test data directory
     python clear_test_data.py \\
         --mode targeted \\
-        --fhir-url https://smile.sparked-fhir.com/ereq/fhir/DEFAULT \\
+        --fhir-url https://smile.sparked-fhir.com/aucore/fhir/DEFAULT \\
         --data-dir /path/to/test-data
 
     # Wipe all resources on a node
     python clear_test_data.py \\
         --mode wipe-all \\
-        --fhir-url https://smile.sparked-fhir.com/ereq/fhir/DEFAULT
+        --fhir-url https://smile.sparked-fhir.com/aucore/fhir/DEFAULT
 
     # Dry run (show what would be deleted)
     python clear_test_data.py \\
         --mode targeted \\
-        --fhir-url https://smile.sparked-fhir.com/ereq/fhir/DEFAULT \\
+        --fhir-url https://smile.sparked-fhir.com/aucore/fhir/DEFAULT \\
         --data-dir /path/to/test-data \\
         --dry-run
 

--- a/scripts/multitenancy_phase0_tests.sh
+++ b/scripts/multitenancy_phase0_tests.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Phase 0 multitenancy rehearsal against a Sparked Dev FHIR Server node.
-# Target node comes from PHASE0_NODE (default ereq); results path from PHASE0_RESULTS.
+# Target node comes from PHASE0_NODE (default aucore); results path from PHASE0_RESULTS.
 # Creates a temporary MTTEST partition, verifies isolation properties, then cleans up.
 # Admin credentials are fetched from AWS Secrets Manager at runtime and kept in memory only.
 set -u
 
-NODE="${PHASE0_NODE:-ereq}"
+NODE="${PHASE0_NODE:-aucore}"
 BASE="https://smile.sparked-fhir.com/$NODE/fhir"
 ADMINJSON="https://smile.sparked-fhir.com/$NODE/admin-json"
 PART_ID=9001

--- a/scripts/register_smart_client.py
+++ b/scripts/register_smart_client.py
@@ -72,14 +72,14 @@ DEFAULT_BASE_URL = "https://smile.sparked-fhir.com"
 # Each node has its own smart_auth and local_security modules (from useDefaultModules).
 # Clients and users must be registered per-node on that node's smart_auth module.
 MODULE_ID = "smart_auth"
-SUPPORTED_NODES = ["aucore", "ereq"]
+# aucore is the only node since the ereq and hl7au decommission (2026-08-02).
+SUPPORTED_NODES = ["aucore"]
 DEFAULT_NODE = "aucore"
 
 # Node-specific configuration for SMART auth context paths and admin API paths.
 # Each node's smart_auth module listens on its own context path.
 NODE_CONFIG = {
     "aucore": {"smartauth_path": "aucore/smartauth", "admin_path": "aucore/admin-json"},
-    "ereq":   {"smartauth_path": "ereq/smartauth",   "admin_path": "ereq/admin-json"},
 }
 
 

--- a/scripts/sync_packages.py
+++ b/scripts/sync_packages.py
@@ -6,7 +6,7 @@ This script synchronizes FHIR IG packages across SmileCDR nodes.
 
 Usage:
     # From GitHub Actions workflow
-    python sync_packages.py --base-url https://smile.sparked-fhir.com --nodes aucore,ereq --source config --dry-run
+    python sync_packages.py --base-url https://smile.sparked-fhir.com --nodes aucore --source config --dry-run
 
     # Or sync all nodes from config
     python sync_packages.py --base-url https://smile.sparked-fhir.com --nodes all --source config

--- a/scripts/sync_smart_auth.py
+++ b/scripts/sync_smart_auth.py
@@ -22,9 +22,10 @@ Canonical configuration per node:
                                  context-ehr-encounter (the launch script
                                  injects encounter context)
 
-hl7au is deliberately excluded: its live smart_auth predates the per-node
-layout (bare /smartauth context path, default-keystore). See
-docs/smart-auth-config.md.
+aucore is the only supported node since the ereq and hl7au decommission
+(2026-08-02). hl7au had always been excluded anyway: its live smart_auth
+predated the per-node layout (bare /smartauth context path, default-keystore).
+See docs/smart-auth-config.md.
 
 API Reference:
     https://smilecdr.com/docs/json_admin_endpoints/module_config_endpoint.html
@@ -41,7 +42,7 @@ Usage:
     python sync_smart_auth.py --apply
 
     # Single node
-    python sync_smart_auth.py --apply --node ereq
+    python sync_smart_auth.py --apply --node aucore
 
     # Archive the unused appSphere module (see docs/smart-auth-config.md)
     python sync_smart_auth.py --archive-app-gallery --apply
@@ -83,7 +84,7 @@ except ImportError:
 DEFAULT_BASE_URL = "https://smile.sparked-fhir.com"
 MODULE_ID = "smart_auth"
 APP_GALLERY_MODULE_ID = "app_gallery"
-SUPPORTED_NODES = ["aucore", "ereq"]
+SUPPORTED_NODES = ["aucore"]
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "module-config" / "smart-post-authorize.js"
 

--- a/scripts/update_node_packages.py
+++ b/scripts/update_node_packages.py
@@ -10,19 +10,19 @@ Usage:
     # Add package to nodes
     python update_node_packages.py \
         --action add \
-        --nodes aucore,ereq \
+        --nodes aucore \
         --package package-international-patient-summary-2.0.0.json
 
     # Remove package from nodes
     python update_node_packages.py \
         --action remove \
-        --nodes aucore,ereq \
+        --nodes aucore \
         --package package-international-patient-summary-2.0.0.json
 
     # Preview changes without applying
     python update_node_packages.py \
         --action add \
-        --nodes aucore,ereq \
+        --nodes aucore \
         --package package-international-patient-summary-2.0.0.json \
         --dry-run
 """

--- a/scripts/upgrade_smoke_tests.sh
+++ b/scripts/upgrade_smoke_tests.sh
@@ -10,7 +10,7 @@
 #   -o FILE             write markdown results to FILE (default: upgrade-smoke-results.md)
 #   --expect-version V  fail if any node does not report Smile CDR version V
 #   --write             also do a create/read/delete round-trip with a tagged test
-#                       Patient on ereq DEFAULT (off by default)
+#                       Patient on aucore DEFAULT (off by default)
 #   --connect-to HOST   send every request to load balancer HOST (e.g. the Envoy
 #                       Gateway NLB) while keeping SNI and the Host header as
 #                       smile.sparked-fhir.com. Lets a new load balancer be verified
@@ -21,8 +21,12 @@
 set -u
 
 BASE="https://smile.sparked-fhir.com"
-NODES=(aucore hl7au ereq)
-EREQ_TENANTS=(DEFAULT SCENARIO-EREQ-MEDS VENDOR-DEMO)
+# aucore is the only node since the ereq and hl7au decommission (2026-08-02).
+NODES=(aucore)
+# Tenants to exercise. Partitions are runtime objects, not config, so keep this in
+# step with the live tenant list (admin console, Partition Management). This was
+# the ereq tenant set until the decommission.
+AUCORE_TENANTS=(DEFAULT)
 RESULTS="upgrade-smoke-results.md"
 EXPECT_VERSION=""
 DO_WRITE=0
@@ -116,12 +120,12 @@ for node in "${NODES[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# ereq tenant checks (multitenancy)
+# aucore tenant checks (multitenancy)
 # ---------------------------------------------------------------------------
 note ""
-note "## ereq tenants"
-for tenant in "${EREQ_TENANTS[@]}"; do
-  fhir="$BASE/ereq/fhir/$tenant"
+note "## aucore tenants"
+for tenant in "${AUCORE_TENANTS[@]}"; do
+  fhir="$BASE/aucore/fhir/$tenant"
   code=$(anoncurl -o "$TMP/meta.json" -w "%{http_code}" "$fhir/metadata")
   [ "$code" = "200" ] && ok "$tenant metadata HTTP 200" || bad "$tenant metadata HTTP $code"
   code=$(acurl -o "$TMP/count.json" -w "%{http_code}" "$fhir/Patient?_summary=count")
@@ -172,7 +176,7 @@ fi
 # ---------------------------------------------------------------------------
 note ""
 note "## AU Patient Summary (\$summary, custom AUPS generator)"
-for target in "aucore DEFAULT" "ereq SCENARIO-EREQ-MEDS"; do
+for target in "aucore DEFAULT"; do
   set -- $target; node=$1; tenant=$2
   fhir="$BASE/$node/fhir/$tenant"
   code=$(acurl -o "$TMP/p.json" -w "%{http_code}" "$fhir/Patient?_count=1")
@@ -191,12 +195,17 @@ for target in "aucore DEFAULT" "ereq SCENARIO-EREQ-MEDS"; do
 done
 
 # ---------------------------------------------------------------------------
-# Optional write path: create/read/delete a tagged test Patient (ereq DEFAULT)
+# Optional write path: create/read/delete a tagged test Patient (aucore DEFAULT)
+#
+# Moved from ereq DEFAULT at the ereq decommission. This writes into the curated
+# shared dataset, so it stays off by default and the resource is deleted again
+# immediately. It uses the admin credential, which multitenancy Phase 2 kept
+# read/write on DEFAULT (only participant principals lost write).
 # ---------------------------------------------------------------------------
 if [ "$DO_WRITE" = "1" ]; then
   note ""
-  note "## Write round-trip (ereq DEFAULT)"
-  fhir="$BASE/ereq/fhir/DEFAULT"
+  note "## Write round-trip (aucore DEFAULT)"
+  fhir="$BASE/aucore/fhir/DEFAULT"
   code=$(acurl -o "$TMP/create.json" -w "%{http_code}" -X POST "$fhir/Patient" -d '{
     "resourceType":"Patient",
     "identifier":[{"system":"urn:sparked:upgrade-smoke","value":"upgrade-smoke-test"}],


### PR DESCRIPTION
Closes #85.

AU eRequesting is no longer run under Sparked and the agreed hosting period for `ereq` ran to end July 2026, after the Sparked Testing Event. `hl7au` is decommissioned alongside it on the environment owner's direction. **aucore becomes the only node of the Sparked Dev FHIR Server.**

## Stage 1 of 2, deliberately reversible

Both nodes are set `enabled: false`. Their config blocks, their `db_users` entries in `terraform/main.tf` and **their databases are all retained**, so this stays a one-line revert for as long as the data is still wanted.

A follow-up PR does the destructive half once the data is confirmed unneeded: delete the two node blocks, drop the `ereq`/`hl7au` `db_users` entries (which drops the databases), and remove `package-au-erequesting-1.0.0.json` with its `helm_chart_mapped_files` entry and values-common.yaml reference. Only ereq seeded that package. The header of `simplified-multinode.yaml` records this so the next person does not have to rediscover it.

## Two things that are NOT affected, and are easy to confuse

- **The AU eRequesting IG package (`hl7.fhir.au.ereq`) is a different thing from the ereq node.** The terminology servers still publish it, so nothing under `terminology-servers/` changes.
- **The `hl7au` node is not the HL7 AU reference server at `fhir.hl7.org.au`,** which is a separate system outside this repo's control.

## Everything else that would point at a dead node

The node flags alone would leave several things dispatching at, or offering, a node that no longer exists. Fixed in the same change so the decommission is not half-done:

| Area | Change | Why it matters |
|---|---|---|
| `upgrade_smoke_tests.sh` | `NODES=(aucore)`; tenant checks and the optional `--write` round-trip move to aucore; drop the ereq `$summary` target | **Every smoke run would fail after the apply otherwise** |
| `clear-test-data.yml`, `load-test-data.yml` | drop the `ereq` choice and its FHIR URL mapping | a "clear" dispatched at a dead node is a confusing failure at best |
| `manage-test-data.yml` | drop `clear-and-load-ereq` and `clear-and-load-aucore-and-ereq` and their four jobs | |
| `issue-opened.yml`, `issue-labeled.yml` | node parsers no longer select `ereq` | issues opened before today may still tick it; it is now ignored rather than dispatched |
| `register_smart_client.py`, `sync_smart_auth.py` | `SUPPORTED_NODES = ["aucore"]` | |
| `multitenancy_phase0_tests.sh` | `PHASE0_NODE` defaults to aucore | its old default was ereq |
| Issue templates 01, 03, 05, 06 | stop offering `ereq` | the request forms are the front door |
| `SERVICE-CATALOGUE.md`, `scripts/README.md` | describe a single-node server | |

The optional write round-trip now targets aucore DEFAULT, which is the curated shared dataset. It stays off by default, deletes the resource immediately, and uses the admin credential, which multitenancy Phase 2 deliberately kept read/write on DEFAULT.

## Verification

- All 12 workflow and 6 issue-template YAML files parse.
- All 9 Python scripts compile.
- Both bash scripts pass `bash -n`.
- `simplified-multinode.yaml` parses.
- `validate-config.yml`'s package-reference check still passes: no package file is removed in this stage.

## Before merging

The issue asks for a Zulip announcement and a Confluence update. Neither is in this PR.