### PR TITLE
Fix IG-release automation: startup failure, broken package sync, hidden package versions

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -33,10 +33,16 @@ on:
           - bundle
           - transaction
 
+# A reusable workflow may only request permissions the caller already holds, and
+# GitHub validates that for the WHOLE file at startup. load-test-data.yml needs
+# id-token: write for its ECR OIDC login, so omitting it here does not just break
+# load-test-data-execute: it fails the entire workflow with startup_failure, and
+# every unrelated job (create-ig-pr included) never starts.
 permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   # ============================================================================

--- a/.github/workflows/reload-ig-config.yml
+++ b/.github/workflows/reload-ig-config.yml
@@ -89,25 +89,38 @@ jobs:
       - name: Install dependencies
         run: pip install -r scripts/requirements.txt
 
+      # Every value arrives via env rather than inline ${{ }}. Interpolating the
+      # custom_packages JSON straight into a shell assignment let its own double
+      # quotes close the string, so the value reached the script as
+      # [{name: hl7.fhir.au.base, ...}] and no longer parsed as JSON. Env passing
+      # also keeps issue-supplied text out of the executed script.
+      #
+      # custom_packages is written with the heredoc form because a JSON blob is
+      # multi-line-capable; the KEY=value form silently truncates at the first
+      # newline.
       - name: Determine input source
         id: inputs
+        env:
+          IN_BASE_URL: ${{ inputs.base_url || github.event.inputs.base_url }}
+          IN_NODES: ${{ inputs.nodes || github.event.inputs.nodes }}
+          IN_PACKAGE_SOURCE: ${{ inputs.package_source || github.event.inputs.package_source }}
+          IN_CUSTOM_PACKAGES: ${{ inputs.custom_packages || github.event.inputs.custom_packages }}
+          IN_DRY_RUN: ${{ inputs.dry_run != '' && inputs.dry_run || github.event.inputs.dry_run }}
+          IN_FORCE_REINSTALL: ${{ inputs.force_reinstall != '' && inputs.force_reinstall || github.event.inputs.force_reinstall }}
+          IN_ISSUE_NUMBER: ${{ inputs.issue_number || github.event.inputs.issue_number }}
         run: |
           # Use workflow_call inputs if available, otherwise use workflow_dispatch inputs
-          BASE_URL="${{ inputs.base_url || github.event.inputs.base_url }}"
-          NODES="${{ inputs.nodes || github.event.inputs.nodes }}"
-          PACKAGE_SOURCE="${{ inputs.package_source || github.event.inputs.package_source }}"
-          CUSTOM_PACKAGES="${{ inputs.custom_packages || github.event.inputs.custom_packages }}"
-          DRY_RUN="${{ inputs.dry_run != '' && inputs.dry_run || github.event.inputs.dry_run }}"
-          FORCE_REINSTALL="${{ inputs.force_reinstall != '' && inputs.force_reinstall || github.event.inputs.force_reinstall }}"
-          ISSUE_NUMBER="${{ inputs.issue_number || github.event.inputs.issue_number }}"
-
-          echo "base_url=$BASE_URL" >> $GITHUB_OUTPUT
-          echo "nodes=$NODES" >> $GITHUB_OUTPUT
-          echo "package_source=$PACKAGE_SOURCE" >> $GITHUB_OUTPUT
-          echo "custom_packages=$CUSTOM_PACKAGES" >> $GITHUB_OUTPUT
-          echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
-          echo "force_reinstall=$FORCE_REINSTALL" >> $GITHUB_OUTPUT
-          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          {
+            echo "base_url=$IN_BASE_URL"
+            echo "nodes=$IN_NODES"
+            echo "package_source=$IN_PACKAGE_SOURCE"
+            echo "dry_run=$IN_DRY_RUN"
+            echo "force_reinstall=$IN_FORCE_REINSTALL"
+            echo "issue_number=$IN_ISSUE_NUMBER"
+            echo "custom_packages<<CUSTOM_PACKAGES_EOF"
+            echo "$IN_CUSTOM_PACKAGES"
+            echo "CUSTOM_PACKAGES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run package synchronization script
         id: sync
@@ -122,27 +135,29 @@ jobs:
           DRY_RUN: ${{ steps.inputs.outputs.dry_run }}
           FORCE_REINSTALL: ${{ steps.inputs.outputs.force_reinstall }}
         run: |
-          # Build command arguments as an array so the custom_packages JSON is
-          # preserved as one quoted argument (previously the quotes were stripped
-          # by word-splitting, breaking the 'custom' source).
-          ARGS=(--nodes "$NODES" --source "$PACKAGE_SOURCE")
+          # Build the argument list with the POSIX positional parameters, not a
+          # bash array. python:3.12-slim ships no bash, so the runner falls back
+          # to `sh -e {0}` and ARGS=(...) is a syntax error that failed this step
+          # on every input, not just the 'custom' source. `set --` keeps the
+          # custom_packages JSON as one argument the same way an array would.
+          set -- --nodes "$NODES" --source "$PACKAGE_SOURCE"
 
           if [ "$DRY_RUN" = "true" ]; then
-            ARGS+=(--dry-run)
+            set -- "$@" --dry-run
           fi
 
           if [ "$FORCE_REINSTALL" = "true" ]; then
-            ARGS+=(--force-reinstall)
+            set -- "$@" --force-reinstall
           fi
 
           if [ "$PACKAGE_SOURCE" = "custom" ]; then
-            ARGS+=(--packages "$CUSTOM_PACKAGES")
+            set -- "$@" --packages "$CUSTOM_PACKAGES"
           fi
 
           # Run the script and capture output
-          echo "Running: python scripts/sync_packages.py ${ARGS[*]}"
+          echo "Running: python scripts/sync_packages.py $*"
           set +e  # Don't exit on error
-          OUTPUT=$(python scripts/sync_packages.py "${ARGS[@]}" 2>&1)
+          OUTPUT=$(python scripts/sync_packages.py "$@" 2>&1)
           EXIT_CODE=$?
           set -e
 
@@ -188,11 +203,16 @@ jobs:
       - name: Post results to issue
         if: always() && steps.inputs.outputs.issue_number != ''
         uses: actions/github-script@v7
+        env:
+          # The sync log is server-controlled text. Interpolated into the script
+          # body it would break the surrounding template literal on any backtick
+          # or ${ it contains, so read it from env at runtime instead.
+          SYNC_RESULT: ${{ steps.sync.outputs.result }}
         with:
           script: |
             const issueNumber = parseInt('${{ steps.inputs.outputs.issue_number }}');
             const status = '${{ steps.sync.outputs.status }}';
-            const output = `${{ steps.sync.outputs.result }}`;
+            const output = process.env.SYNC_RESULT || '';
             const nodes = '${{ steps.inputs.outputs.nodes }}';
             const dryRun = '${{ steps.inputs.outputs.dry_run }}' === 'true';
 


### PR DESCRIPTION
Four defects left the IG-release path non-functional and its reporting unreliable. Every `issue-labeled` run since 2026-07-28 ended in `startup_failure`, and the two open IG release requests (#84, #86) never produced a PR.

## Workflow fixes

**`issue-labeled.yml`: add `id-token: write`.** It calls `load-test-data.yml` as a reusable workflow, and that workflow requires `id-token: write` for its ECR OIDC login (added when the test-data loader moved to `docker run`). A reusable workflow may only request permissions the caller holds, and GitHub validates this for the whole file at startup, so the missing permission failed every job in the file, including `create-ig-pr`, before any of them started. `manage-test-data.yml`, the other caller, already grants it.

**`reload-ig-config.yml`: POSIX argument building.** The job runs in `python:3.12-slim`, which has no bash, so the runner falls back to `sh -e {0}` and `ARGS=(...)` was a syntax error. This failed the sync step on every input, not only the `custom` source, which is why the previous two runs of this workflow also failed.

**`reload-ig-config.yml`: pass inputs via env.** The `custom_packages` JSON was assigned as `CUSTOM_PACKAGES="${{ ... }}"`, so its own double quotes closed the shell string and the value reached the script as `[{name: hl7.fhir.au.base, ...}]`, which is not JSON. The heredoc output form is used so a multi-line blob is not truncated at the first newline. Env passing also keeps issue-supplied text out of the executed script.

**`reload-ig-config.yml`: read the sync log from env in the issue-comment step.** It was interpolated into a JavaScript template literal, which breaks on any backtick or `${` in the server's response.

## Script fixes

**`sync_packages.py`: read the packument, not the search index.** `/-/v1/search` returns a single object per package id, so it cannot see a version that is stored but not current. `is_package_installed` relied on it and therefore reported a correctly stored non-current version as a failed install, which is exactly what happened when installing `hl7.terminology.r4@7.2.0` alongside 7.3.0. Now reads `/package/npm/<name>`, which lists every version, and falls back to the search index when unavailable. A live run also logs the full version list per processed package.

**`reload-ig-config.yml`: expose `skip_uninstall`.** `sync_packages.py` removes any other version of the same package id before installing. That is its own policy, not a SmileCDR constraint: the registry holds several versions at once. The script already supported `--skip-uninstall`; the workflow never exposed it. Needed on aucore, where the installed packages pin conflicting terminology versions.

## Verification

Dispatched the fixed workflow against aucore repeatedly. The custom source now parses, and the packument change resolved the false failure. Confirmed four versions of one package coexisting, which the old code could not see:

```
Registry holds hl7.terminology.r4: 6.2.0, 7.1.0, 7.2.0, 7.3.0
```

`aucore/fhir/metadata` returns 200 and the pod has not restarted (45h uptime) across the whole exercise.