### PR TITLE
Pin the ballot dependencies, and stop hiding non-current package versions

### DIFF
--- a/.github/workflows/reload-ig-config.yml
+++ b/.github/workflows/reload-ig-config.yml
@@ -34,6 +34,11 @@ on:
         required: true
         default: false
         type: boolean
+      skip_uninstall:
+        description: "Install without removing other versions of the same package, so several versions coexist"
+        required: false
+        default: false
+        type: boolean
       issue_number:
         description: "Issue number to post results to (optional)"
         required: false
@@ -59,6 +64,10 @@ on:
         type: boolean
         default: false
       force_reinstall:
+        required: false
+        type: boolean
+        default: false
+      skip_uninstall:
         required: false
         type: boolean
         default: false
@@ -107,6 +116,7 @@ jobs:
           IN_CUSTOM_PACKAGES: ${{ inputs.custom_packages || github.event.inputs.custom_packages }}
           IN_DRY_RUN: ${{ inputs.dry_run != '' && inputs.dry_run || github.event.inputs.dry_run }}
           IN_FORCE_REINSTALL: ${{ inputs.force_reinstall != '' && inputs.force_reinstall || github.event.inputs.force_reinstall }}
+          IN_SKIP_UNINSTALL: ${{ inputs.skip_uninstall != '' && inputs.skip_uninstall || github.event.inputs.skip_uninstall }}
           IN_ISSUE_NUMBER: ${{ inputs.issue_number || github.event.inputs.issue_number }}
         run: |
           # Use workflow_call inputs if available, otherwise use workflow_dispatch inputs
@@ -116,6 +126,7 @@ jobs:
             echo "package_source=$IN_PACKAGE_SOURCE"
             echo "dry_run=$IN_DRY_RUN"
             echo "force_reinstall=$IN_FORCE_REINSTALL"
+            echo "skip_uninstall=$IN_SKIP_UNINSTALL"
             echo "issue_number=$IN_ISSUE_NUMBER"
             echo "custom_packages<<CUSTOM_PACKAGES_EOF"
             echo "$IN_CUSTOM_PACKAGES"
@@ -134,6 +145,7 @@ jobs:
           CUSTOM_PACKAGES: ${{ steps.inputs.outputs.custom_packages }}
           DRY_RUN: ${{ steps.inputs.outputs.dry_run }}
           FORCE_REINSTALL: ${{ steps.inputs.outputs.force_reinstall }}
+          SKIP_UNINSTALL: ${{ steps.inputs.outputs.skip_uninstall }}
         run: |
           # Build the argument list with the POSIX positional parameters, not a
           # bash array. python:3.12-slim ships no bash, so the runner falls back
@@ -148,6 +160,14 @@ jobs:
 
           if [ "$FORCE_REINSTALL" = "true" ]; then
             set -- "$@" --force-reinstall
+          fi
+
+          # sync_packages.py removes any other version of the same package id by
+          # default. SmileCDR itself keys the registry on (package id, version)
+          # and is happy to hold several versions at once, which is what lets
+          # packages with conflicting dependency pins coexist on one node.
+          if [ "$SKIP_UNINSTALL" = "true" ]; then
+            set -- "$@" --skip-uninstall
           fi
 
           if [ "$PACKAGE_SOURCE" = "custom" ]; then

--- a/module-config/packages/package-hl7-terminology-7.3.0.json
+++ b/module-config/packages/package-hl7-terminology-7.3.0.json
@@ -1,0 +1,6 @@
+{
+  "name": "hl7.terminology.r4",
+  "version": "7.3.0",
+  "installMode": "STORE_AND_INSTALL",
+  "fetchDependencies": false
+}

--- a/module-config/packages/package-smart-app-launch-2.2.0.json
+++ b/module-config/packages/package-smart-app-launch-2.2.0.json
@@ -1,0 +1,6 @@
+{
+  "name": "hl7.fhir.uv.smart-app-launch",
+  "version": "2.2.0",
+  "installMode": "STORE_AND_INSTALL",
+  "fetchDependencies": false
+}

--- a/module-config/simplified-multinode.yaml
+++ b/module-config/simplified-multinode.yaml
@@ -51,7 +51,12 @@ cdrNodes:
           seed.base_validation_resources: true
           package_registry.resource_status_validation_filter.enabled: false
           package_registry.load_specs_asynchronously: false
-          package_registry.startup_installation_specs: "classpath:/config_seeding/package-au-base-7.0.0-ballot1.json classpath:/config_seeding/package-au-patient-summary-1.0.0.json classpath:/config_seeding/package-aucore-3.0.0-ballot1.json classpath:/config_seeding/package-international-patient-summary-2.0.1.json"
+          # Dependencies first. apply_ig_release.py appends a brand new package,
+          # but hl7.terminology and smart-app-launch are dependencies of the AU
+          # Base and AU Core ballots, so on a fresh node they have to be present
+          # before those install. Order is significant here and is preserved on
+          # subsequent version bumps, which replace in place.
+          package_registry.startup_installation_specs: "classpath:/config_seeding/package-hl7-terminology-7.3.0.json classpath:/config_seeding/package-smart-app-launch-2.2.0.json classpath:/config_seeding/package-au-base-7.0.0-ballot1.json classpath:/config_seeding/package-au-patient-summary-1.0.0.json classpath:/config_seeding/package-aucore-3.0.0-ballot1.json classpath:/config_seeding/package-international-patient-summary-2.0.1.json"
           # Pulled from the live aucore node (2026-07-20) to eliminate seed drift.
           # Adds CarePlan/Goal/CareTeam (patient Care Plan viewer support) and the
           # DiagnosticReport/DocumentReference/MedicationDispense/Endpoint/Bundle

--- a/module-config/values-common.yaml
+++ b/module-config/values-common.yaml
@@ -51,6 +51,10 @@ mappedFiles:
     path: /home/smile/smilecdr/classes/config_seeding
   package-aucore-3.0.0-ballot1.json:
     path: /home/smile/smilecdr/classes/config_seeding
+  package-hl7-terminology-7.3.0.json:
+    path: /home/smile/smilecdr/classes/config_seeding
+  package-smart-app-launch-2.2.0.json:
+    path: /home/smile/smilecdr/classes/config_seeding
 
 # Mount users.json from AWS Secrets Manager
 secrets:

--- a/scripts/sync_packages.py
+++ b/scripts/sync_packages.py
@@ -106,13 +106,37 @@ class SmileCDRPackageSync:
             # Continue anyway - package might not be installed
             return False
 
+    def get_installed_versions(self, node_name: str, package_name: str) -> List[str]:
+        """Return every version of one package id stored on a node.
+
+        Reads the npm packument rather than the search index. `/-/v1/search`
+        reports a single object per package id, so it cannot see a version that
+        is stored but not current, whereas SmileCDR keys the registry on
+        (package id, version) and holds several versions at once.
+        """
+        url = f"{self.base_url}/{node_name}/package/npm/{package_name}"
+        try:
+            response = requests.get(url, headers=self.headers, timeout=30)
+            response.raise_for_status()
+            return sorted((response.json().get('versions') or {}).keys())
+        except (requests.exceptions.RequestException, ValueError):
+            return []
+
     def is_package_installed(self, node_name: str, package_name: str, package_version: str) -> bool:
         """Return True if a specific package@version is registered on a node.
 
         Used to confirm the real post-install state, since SmileCDR can return a
-        500 while re-inserting an already-present dependency even though the
-        target package itself installed correctly.
+        500 or time out at the ingress while the install itself succeeds.
+
+        Checks the packument first so a correctly stored non-current version is
+        not reported as a failed install; falls back to the search index when
+        the packument is unavailable.
         """
+        versions = self.get_installed_versions(node_name, package_name)
+        if versions:
+            print(f"      Registry holds {package_name}: {', '.join(versions)}")
+            return package_version in versions
+
         url = f"{self.base_url}/{node_name}/package/npm/-/v1/search"
         try:
             response = requests.get(url, headers=self.headers, timeout=30)
@@ -236,6 +260,14 @@ class SmileCDRPackageSync:
             success = self.install_package(node_name, package)
             if not success and not self.dry_run:
                 failed_operations.append(f"Install {package_key} on {node_name}")
+
+        if not self.dry_run:
+            # Report every stored version, not just the current one, so a bump
+            # that left an older version behind is visible in the run log.
+            print(f"\n📋 Registry state for the packages just processed:")
+            for name in dict.fromkeys(p['name'] for p in desired_packages):
+                versions = self.get_installed_versions(node_name, name)
+                print(f"   {name}: {', '.join(versions) if versions else '(none)'}")
 
         print(f"\n{'=' * 80}")
         print(f"Completed processing node: {node_name}")

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -103,6 +103,16 @@ module "smile_cdr_dependencies" {
       location = "classes/config_seeding"
       data     = file("../module-config/packages/package-aucore-3.0.0-ballot1.json")
     },
+    {
+      name     = "package-hl7-terminology-7.3.0.json"
+      location = "classes/config_seeding"
+      data     = file("../module-config/packages/package-hl7-terminology-7.3.0.json")
+    },
+    {
+      name     = "package-smart-app-launch-2.2.0.json"
+      location = "classes/config_seeding"
+      data     = file("../module-config/packages/package-smart-app-launch-2.2.0.json")
+    },
     # Users configuration moved to AWS Secrets Manager - see extra_secrets below
   ]
 


### PR DESCRIPTION
Follow-up to #90 and #91. Those merged before these three commits were pushed, so this carries the remainder.

## Pin the dependencies the ballots declare

AU Base 7.0.0-ballot1 and AU Core 3.0.0-ballot1 both declare `hl7.terminology.r4@7.3.0`, and AU Core declares `hl7.fhir.uv.smart-app-launch@2.2.0`. aucore carried 7.2.0 and 2.0.0.

`fetchDependencies: true` does not close that gap. Tested live: SmileCDR treats a dependency as satisfied when any version of the package id is present, so it never upgrades one. `smart-app-launch` is the clean case, 2.2.0 was simply absent until installed explicitly. So both are pinned as explicit package files with `fetchDependencies` left `false`.

They are ordered ahead of the IG packages in `startup_installation_specs`. `apply_ig_release.py` appends a brand new package, but these are dependencies of the ballots and must install first on a fresh node. Version bumps replace in place and preserve the order, so this only needed doing once.

## Stop hiding non-current package versions

`/package/npm/-/v1/search` returns one object per package id, so it only ever reports the *current* version. `sync_packages.py` built its whole view of the server from it, which had two consequences:

- `is_package_installed` reported a correctly stored non-current version as a failed install. That is what happened installing `hl7.terminology.r4@7.2.0` alongside 7.3.0.
- Every "installed packages" listing was quietly incomplete. aucore had been holding `hl7.terminology.r4` at 6.2.0 and 7.1.0 for months with no way to see it.

Now reads the packument, `GET /<node>/package/npm/<id>`, which lists every version, and falls back to the search index when unavailable. A live run also logs the full version list per processed package.

## Expose `skip_uninstall`

`sync_packages.py` removes any other version of the same package id before installing. That is its own policy, not a SmileCDR constraint: the registry keys on (package id, version) and holds several versions at once. The script already supported `--skip-uninstall`; the workflow never exposed it.

This matters on aucore because the installed set pins conflicting terminology versions: `au.ps@1.0.0` and `ips@2.0.1` declare 7.2.0, `ipa@1.1.0` declares 6.2.0, the ballots declare 7.3.0. Pinning 7.3.0 does not have to take 7.2.0 away from the packages that want it.

## Verification

Confirmed live on aucore, four versions of one package coexisting, which the old code could not see:

```
Registry holds hl7.terminology.r4: 6.2.0, 7.1.0, 7.2.0, 7.3.0
hl7.fhir.uv.smart-app-launch: 2.0.0, 2.2.0
```

`hl7.terminology.r4@7.3.0` and `smart-app-launch@2.2.0` are current. `aucore/fhir/metadata` returns 200 and the pod has not restarted (45h uptime) across the exercise. `terraform fmt -check`, `actionlint` and both YAML parses pass.

One operational note: replacing the current version of a large package triggers a long server-side expunge of the superseded content, which pinned the pod at ~1000m CPU for several minutes and caused intermittent 15s ingress timeouts. It recovers on its own without a restart. Worth expecting on any future terminology bump, and worth not stacking further installs on top while it drains.