### PR TITLE
Seed the Platypus demo client and user from config

### DIFF
--- a/docs/platypus-demo-tenant.md
+++ b/docs/platypus-demo-tenant.md
@@ -1,0 +1,89 @@
+# The Platypus demo tenant on `aucore`
+
+Platypus Health is a patient-held personal health record app that connects to
+this server as a SMART App Launch client. It uses two partitions on the `aucore`
+node, for different reasons, and the split is easy to get wrong.
+
+| Partition | What Platypus uses it for | Writable |
+| --- | --- | --- |
+| `DEFAULT` | The curated AU Core dataset it reads as a patient's clinical history, and the shared conformance resources (`Questionnaire`, `StructureDefinition`, `ValueSet`, `CodeSystem`) every tenant needs | No, by design (ADR 0001) |
+| `PLATYPUS` (partition 102) | Anything the demo needs to WRITE: patient-contributed observations, form responses, seeded scenario data | Yes |
+
+## What is seeded from this repository, and what is not
+
+Seeded from here:
+
+- `module-config/platypus-clients.json` — the `platypus-health` SMART client.
+- `module-config/platypus-users.json` — the `platypus-demo-patient` user.
+
+```bash
+python scripts/register_smart_client.py --bulk \
+  --clients-file module-config/platypus-clients.json --node aucore
+python scripts/manage_smart_users.py --bulk \
+  --users-file module-config/platypus-users.json --node aucore
+```
+
+Both are idempotent: run them against the live node and existing records are
+skipped, not overwritten. That makes them safe as a verification step as well as
+a seeding step.
+
+**Not seeded from here:**
+
+- **The `PLATYPUS` partition itself.** It is created through the admin JSON API,
+  like every other partition on this server. Partition creation is not currently
+  expressed in this repository for any tenant, so making an exception for one
+  would be misleading.
+- **Test data.** The tenant is deliberately empty of clinical resources at rest.
+  What belongs in it depends on the scenario being demonstrated, so it is loaded
+  as an operational act (see `aehrc/sparked-test-data-loader`), not held here.
+
+## Why this user has a `DEFAULT` grant, when ADR 0001 says vendor tenants should not
+
+`platypus-demo-patient` carries `FHIR_ACCESS_PARTITION_NAME PLATYPUS,DEFAULT`.
+That is a deliberate exception to the tenant-scoping ADR 0001 describes, and it
+exists because of one concrete failure.
+
+Writing a `QuestionnaireResponse` to `PLATYPUS` was rejected with *"User does not
+have access to Questionnaire resources on the requested partition"*. Smile CDR
+authorises the write against the referenced `Questionnaire` type, and
+conformance/definitional resources live in the shared `DEFAULT` partition rather
+than in each tenant. A tenant-only session therefore cannot write a resource that
+references a shared conformance resource at all.
+
+Granting the `DEFAULT` read is the pragmatic fix, and it grants nothing new in
+practice: `DEFAULT` is already anonymously readable, so the session can reach
+nothing it could not have reached unauthenticated. It stays write-protected.
+
+The cleaner fix would be for the server not to require local access to a
+referenced `Questionnaire` — real `QuestionnaireResponse` resources routinely
+reference a questionnaire hosted elsewhere. That is a design question for the
+Sparked team rather than something to settle in a tenant's config.
+
+## The scope set is read-only, and that may be wrong
+
+The live `platypus-health` registration carries `patient/*.read` and no write
+scope. The client files here record that, because seeding a scope set the server
+does not have would be worse than recording the truth.
+
+Platypus's own notes say a granular vitals write scope
+(`patient/Observation.c?category=vital-signs`) was applied to this client through
+the admin JSON API in July 2026, because `register_smart_client.py --scopes` did
+not take effect under `--update-existing`. That scope is not on the server today.
+Either it was reverted deliberately or it was lost, and **that should be
+established before it is added back here** — the app's write demos target the
+`ereq` node's `PLATYPUS` tenant, so a read-only `aucore` client may well be
+correct.
+
+If `--scopes` still does not apply on `--update-existing`, that is a bug in
+`register_smart_client.py` worth its own issue: it makes the seed file a
+statement of intent rather than a source of truth.
+
+## Launch context
+
+The user's default launch context is `Patient/banks-mia-leanne`, the AU Core
+sample patient in `DEFAULT`. Because tenant identification is URL-based, the
+partition the app connects to decides which copy of that patient it resolves:
+connecting to `.../aucore/fhir/DEFAULT` reads the curated one, and connecting to
+`.../aucore/fhir/PLATYPUS` reads whatever copy has been seeded there. Seeding a
+scenario into `PLATYPUS` therefore means seeding a `Patient` with that id first,
+or the launch context resolves to nothing.

--- a/module-config/platypus-clients.json
+++ b/module-config/platypus-clients.json
@@ -1,0 +1,17 @@
+{
+  "description": "SMART on FHIR client for the Platypus Health app against the aucore node. Register with: python scripts/register_smart_client.py --bulk --clients-file module-config/platypus-clients.json --node aucore",
+  "version": "1.0.0",
+  "notes": "Scopes here are the live registration as read from the admin JSON API on 2026-08-12, which is READ-ONLY. An earlier granular vitals write scope is recorded in the app's own notes but is not present on the server; see docs/platypus-demo-tenant.md before adding a write scope back.",
+  "clients": [
+    {
+      "clientId": "platypus-health",
+      "clientName": "Platypus Health",
+      "clientType": "smart-app-launch",
+      "scopes": ["openid", "fhirUser", "launch/patient", "offline_access", "patient/*.read"],
+      "redirectUris": [
+        "platypus-health://smart/callback",
+        "https://checkin.fhir-examples.com/smart/callback"
+      ]
+    }
+  ]
+}

--- a/module-config/platypus-users.json
+++ b/module-config/platypus-users.json
@@ -1,0 +1,15 @@
+{
+  "description": "User account for the Platypus Health demo tenant on the aucore node. Create with: python scripts/manage_smart_users.py --bulk --users-file module-config/platypus-users.json --node aucore",
+  "version": "1.0.0",
+  "notes": "The password is NOT stored here. This account already exists on aucore (pid 1602); the script is idempotent and will skip it rather than reset the password. On a fresh node the script generates a password and prints it once, which must then be distributed securely. See docs/platypus-demo-tenant.md.",
+  "users": [
+    {
+      "username": "platypus-demo-patient",
+      "givenName": "Mia",
+      "familyName": "Banks",
+      "permissionLevel": "read-write",
+      "patientId": "banks-mia-leanne",
+      "tenant": "PLATYPUS,DEFAULT"
+    }
+  ]
+}


### PR DESCRIPTION
The Platypus Health app connects to the `aucore` node as a SMART client, using a `PLATYPUS` tenant for anything it needs to write and the shared `DEFAULT` partition for the AU Core data it reads. The client registration and the demo user account that make that work were created by hand through the admin JSON API during the demo work in July 2026, and were never written down anywhere.

So they exist only as live server state. `grep -ri platypus` across this repository returns nothing. A user re-seed, a node rebuild or a fresh environment loses both, and the failure shows up as a SMART launch that cannot authenticate rather than as anything naming its cause. This adds them as config.

Fixes #93

## What is here

- `module-config/platypus-clients.json` — the `platypus-health` SMART client
- `module-config/platypus-users.json` — the `platypus-demo-patient` user
- `docs/platypus-demo-tenant.md` — which partition is for what, and the two judgement calls below

Both files follow the `connectathon-*` pattern and need no code change:

```bash
python scripts/register_smart_client.py --bulk \
  --clients-file module-config/platypus-clients.json --node aucore
python scripts/manage_smart_users.py --bulk \
  --users-file module-config/platypus-users.json --node aucore
```

## How it was verified

Both files were dry-run against the live node, and the user payload the script generates is compared field by field with the record read back from the admin API. The authority sets are identical:

| Authority | Live (pid 1602) | Generated from this file |
| --- | --- | --- |
| `ROLE_FHIR_CLIENT` | yes | yes |
| `FHIR_CAPABILITIES` | yes | yes |
| `FHIR_ACCESS_PARTITION_NAME` | `PLATYPUS,DEFAULT` | `PLATYPUS,DEFAULT` |
| `FHIR_ALL_READ` | yes | yes |
| `FHIR_ALL_WRITE` | yes | yes |
| `FHIR_TRANSACTION` | yes | yes |

Launch context matches too (`Patient/banks-mia-leanne`). `--skip-existing` defaults on and compares case-insensitively, so running either script against the live node is a no-op rather than a password reset — which makes them usable as a verification step, not only a seeding step.

## Two things recorded rather than silently encoded

**The `DEFAULT` grant is a deliberate exception to ADR 0001.** A tenant-only session cannot write a `QuestionnaireResponse` at all: Smile CDR authorises the write against the referenced `Questionnaire` type, and conformance resources live in the shared partition rather than in each tenant. The grant adds no reachable data, since `DEFAULT` is already anonymously readable and stays write-protected. The cleaner fix would be for the server not to require local access to a referenced `Questionnaire`, since real responses routinely reference one hosted elsewhere, but that is a design question for the team rather than something to settle in a tenant's config.

**The scope set here is the live read-only one, and it may be wrong.** Platypus's notes record a granular vitals write scope (`patient/Observation.c?category=vital-signs`) applied to this client through the admin API in July 2026, because `register_smart_client.py --scopes` did not take effect under `--update-existing`. That scope is not on the server today. I have recorded what is actually there rather than what was intended, because seeding a scope set the server does not have is worse than recording the truth — but somebody should establish which is correct. The app's write demos target the `ereq` node, so a read-only `aucore` client may well be right.

If `--scopes` still fails to apply under `--update-existing`, that is a bug worth its own issue: it makes any client seed file a statement of intent rather than a source of truth. Happy to raise it separately.

## Deliberately not included

- **The `PLATYPUS` partition itself** (102 on `aucore`). Partition creation is not expressed in this repository for any tenant, so making an exception for one would be misleading about how partitions are managed. Say the word if partition seeding is something you want and I will extend this.
- **Test data.** The tenant holds no clinical resources at rest, and what belongs in it depends on the scenario being demonstrated, so it is loaded operationally via `aehrc/sparked-test-data-loader` rather than held here.
- **Any change to live server state.** Nothing in this PR has been applied; the dry runs were read-only.
